### PR TITLE
Bug fix for YR Rebalance Patch

### DIFF
--- a/INI/Game Options/Yuri Rebalance Patch.ini
+++ b/INI/Game Options/Yuri Rebalance Patch.ini
@@ -1,6 +1,6 @@
 ;============ YURI REBALANCE PATCH ============
-;> Version : 1.31
-;> Date : 31/12/2018
+;> Version : 1.32
+;> Date : 12/09/2019
 
 
 ;============ RELEASE NOTES ============
@@ -148,27 +148,3 @@ Soylent=100
 ;> Increased Virus' weapon range by 2 to make it a viable counter to Desolators.
 [Virusgun]
 Range=12
-
-;> V3 Missiles now deal damage to the units inside tank bunkers as well as the bunker.
-[V3WH]
-PenetratesBunker=yes
-[V3EWH]
-PenetratesBunker=yes
-
-;> Dreadnought Missiles now deal damage to the units inside tank bunkers as well as the bunker.
-[DMISLWH]
-PenetratesBunker=yes
-[DMISLEWH]
-PenetratesBunker=yes
-
-;>Boomer Submarine Missiles now deal damage to the units inside tank bunkers as well as the bunker.
-[CMISLWH]
-PenetratesBunker=yes
-[CMISLEWH]
-PenetratesBunker=yes
-
-;>Kirov Bombs now deal damage to the units inside tank bunkers as well as the bunker.
-[BlimpHE]
-PenetratesBunker=yes
-[BlimpHEEffect]
-PenetratesBunker=yes


### PR DESCRIPTION
Removed Bunker penetration ability from V3 Missiles, Dreadnought Missiles, Boomer Submarine Missiles & Kirov Bombs due to this function causing the weapons to deal a lot more damage to other structures than intended.

**Bug reported at:** [https://forums.cncnet.org/topic/10189-issue-with-yuri-balance-patch](https://forums.cncnet.org/topic/10189-issue-with-yuri-balance-patch)

Updated patch version to v1.32