### PR TITLE
Remove .mpr and .yrm map extensions

### DIFF
--- a/Maps/Custom/Custom maps.txt
+++ b/Maps/Custom/Custom maps.txt
@@ -1,1 +1,1 @@
-Any custom maps you made or downloaded are to be placed in this directory. Custom maps need to have a .map, .mpr or .yrm extension. The game mode of custom maps is defined in [Basic] GameMode=.
+Any custom maps you made or downloaded are to be placed in this directory. Custom maps need to have a .map extension. The game mode of custom maps is defined in [Basic] GameMode=.


### PR DESCRIPTION
https://github.com/CnCNet/xna-cncnet-client/blob/2c2b22bc68bd1e6db9b789ecb14d835b7464341a/DXMainClient/Domain/Multiplayer/MapLoader.cs#L124

The program searches only maps with a `.map` extension.