### PR TITLE
Fixed incorrect entries in Yuri's Rebalance Patch

### DIFF
--- a/INI/Game Options/Yuri Rebalance Patch.ini
+++ b/INI/Game Options/Yuri Rebalance Patch.ini
@@ -1,6 +1,6 @@
 ;============ YURI REBALANCE PATCH ============
-;> Version : 1.32
-;> Date : 12/09/2019
+;> Version : 1.34
+;> Date : 07/08/2020
 
 
 ;============ RELEASE NOTES ============
@@ -56,20 +56,22 @@ BuildTimeMultiplier=1.3
 ;> Reduced Gattling weapons damage to infantry armor types by 20% to improve the usefulness of infantry (including the rocketeer) against Yuri. 
 ;> Reduced Gattling weapons damage against terror drones by 75% to make the use of drones a viable option against Yuri.
 ;> Reduced Gattling weapons damage against heavy armored vehicles by 5%.
-;> Set Gattling weapons damage against light armored vehicles back to default. (v1.12)
+;> Set Gattling weapons damage against light armored vehicles back to default. (v1.34)
 [GattWH]
-Verses=80%,65%,55%,90%,30%,5%,10%,5%,3%,125%,50%
+Verses=80%,65%,55%,50%,30%,5%,10%,5%,3%,125%,50%
 
 ;> Set the cost of Gattling Cannon to default. (v1.13)
 
 ;> Increased Chaos Drone's movement speed by 2.
 ;> Set Chaos Drone's build time modifier to default. (v1.14)
 ;> Reduced Chaos Drone's cost by $200, now $800. (v1.30)
+;> Set Chaos drone's sell value to match its new price. (v1.34)
 ;> Increased Chaos Drone's health by 95. (v1.16)
 ;> Reduced Chaos Drone's Berserk effect duration on infantry by 25%.
 ;> Reduced Chaos Drone's Berserk effect duration on vehicles by 25%.
 [CAOS]
 Cost=800
+Soylent=800
 Speed=10
 [PsychGasCreate]
 Verses=75%,75%,75%,25%,25%,25%,0%,0%,0%,0%,0%


### PR DESCRIPTION
Fixed reported bugs at: https://forums.cncnet.org/topic/9250-yuri-rebalance-patch-community-changelog/?do=findComment&comment=81665

- Incorrect Gattling warhead damage to light armour.
- Incorrect soylent value on Chaos drone.