### PR TITLE
Enabled Discord Rich Presence Support

### DIFF
--- a/Resources/ClientDefinitions.ini
+++ b/Resources/ClientDefinitions.ini
@@ -34,6 +34,7 @@ DefaultKeyboardINI=INI\KeyboardMD.ini
 MaxNameLength=12
 Quickmatch=Qt\CnCNetQM.exe
 LauncherExe=CnCNetYRLauncher.exe
+DiscordAppId=786602815480922202
 
 [Links]
 Forum=https://forums.cncnet.org


### PR DESCRIPTION
Enabled Discord rich presence support already in the CnCNet XNA launcher by adding a DiscordAppId entry in the ClientDefinitions.ini.

The DiscordAppId value comes from a Discord Developer portal application that I created. Maintainers can be added to the owning team and ownership can be transferred upon request.