### PR TITLE
Add line to preupdateexec to account for updater delete file bug

### DIFF
--- a/preupdateexec
+++ b/preupdateexec
@@ -13,3 +13,4 @@ wcrate.tem
 wcrate.ubn
 wcrate.urb
 expandspawn09.mix
+do_not_remove_this_line


### PR DESCRIPTION
I noticed that people were commenting how some "pumpkin" crates were still being rendered in the water for some games.

I found that there appears to be a bug in the updater when it reads the `preupdateexec` file. It appears to ignore the last file listed in it. As a work around, I added a line of `do_not_remove_this_line` to the end of it. The updater is able to handle files that do not exist (which this line obviously isn't a file), but it then also resolves the weird bug in it.
