### PR TITLE
fixes #126 - skirmish game speed labels

### DIFF
--- a/Resources/SkirmishLobby.ini
+++ b/Resources/SkirmishLobby.ini
@@ -25,3 +25,6 @@ Visible=false
 
 [tbChatInput]
 Visible=false
+
+[cmbGameSpeedCap]
+Items=Fastest (MAX),Faster (60 FPS),Fast (30 FPS),Medium (20 FPS),Slow (15 FPS),Slower (12 FPS),Slowest (10 FPS)


### PR DESCRIPTION
These values were taken from an old INI file (GameOptions.ini) that was removed in the v6 INI overhaul updates.