### PR TITLE
Add reduced delay checkbox

### DIFF
--- a/Resources/GameOptions.ini
+++ b/Resources/GameOptions.ini
@@ -27,3 +27,4 @@ Bases=Yes
 FogOfWar=No
 SidebarHack=Yes
 AttackNeutralUnits=yes
+ReconnectTimeout=1400

--- a/Resources/MultiplayerGameLobby.ini
+++ b/Resources/MultiplayerGameLobby.ini
@@ -187,7 +187,7 @@ $CC-GO19=chkNoSpawnPreviews:GameLobbyCheckBox
 $CC-GO20=chkNoYuriNoFrance:GameLobbyCheckBox
 $CC-GO21=chkNoSpy:GameLobbyCheckBox
 $CC-GO06=chkNoDogEngiEat:GameLobbyCheckBox
-$CC-GO22=chkInstantDisconnectKick:GameLobbyCheckBox
+$CC-GO22=chkReducedDelay:GameLobbyCheckBox
 
 $CC01=BtnSaveLoadGameOptions:XNAClientButton
 
@@ -458,13 +458,13 @@ Text=No Dog Engineer Kills
 $X=getX(chkNoSpy)
 $Y=getBottom(chkNoSpy) + GAME_OPTION_GAP
 
-[chkInstantDisconnectKick]
-SpawnIniOption=ReconnectTimeout
+[chkReducedDelay]
+SpawnIniOption=FrameSendRate
 DefaultValue=False
-EnabledSpawnIniValue=60
-DisabledSpawnIniValue=2400
-ToolTip=Player(s) who disconnect/lag will be removed from the game without delay. Leave unchecked to allow player(s) to reconnect if they lose connection.
-Text=Auto Disconnect Kick
+EnabledSpawnIniValue=4
+DisabledSpawnIniValue=7
+ToolTip=When enabled input delay is reduced, this is an experimental option. It is best enabled with players of low ping in the room. If FPS drops with the players in your room disable the option.
+Text=Reduced delay
 Checked=False
 $X=getX(chkNoDogEngiEat)
 $Y=getBottom(chkNoDogEngiEat) + GAME_OPTION_GAP


### PR DESCRIPTION
- Remove "Auto Disconnect/Kick" option
- Disconnect timer is reduced down for everyone to 15 seconds as opposed to 30.

![image](https://user-images.githubusercontent.com/6104940/193407065-2f057d11-bed5-4003-9c5e-a9e00ff94a18.png)

- Adds "Reduced delay" option to lobby.
![image](https://user-images.githubusercontent.com/6104940/193407111-f14f7a4f-a0b5-4495-9575-467029d514e7.png)

![image](https://user-images.githubusercontent.com/6104940/193407100-619ef77c-2ebd-4ec2-bcbe-a59940dfe495.png)
