### PR TITLE
New spawner update

### DIFF
--- a/package/Resources/GameOptions.ini
+++ b/package/Resources/GameOptions.ini
@@ -8,6 +8,7 @@
 Sides=America,Korea,France,Germany,Great Britain,Libya,Iraq,Cuba,Russia,Yuri
 StartingLocationAngularVelocity=0.01
 ReservedStartingLocationAngularVelocity=0.01
+SpectatorInternalSideIndex=-3
 
 ; The 8 multiplayer colors. Syntax: <Name>=R,G,B,<in-game color ID>
 [MPColors]


### PR DESCRIPTION
### Observer mode improvements
Prior to this, observers were unable to view underwater units such as dolphins, submarines or squids.  Observers were also unable to see spies, or mirage tanks.  This is now fixed, with thanks to @Belonit, @Starkku and [Phobos](https://github.com/Phobos-developers/Phobos)

### About Latency modes
When playing online, CnCNet announces a latency mode it has selected to players in game. This mode is picked to maintain the highest FPS with the smallest input delay as possible.  What determines the mode selection is based on the players internet connections and latency level between the tunnel server.

 **Latency Mode - 1 - Best** 
There is very little latency between players and no input delay will be experienced. 

 **Latency Mode - 2 - Super** 
There is a low level of latency between players with a little amount of input delay.

 **Latency Mode - 3 - Excellent** 
 **Latency Mode - 4 - Very Good** 
There is a low-medium level of latency between players with a small amount of input delay. 

 **Latency Mode - 5/6 - Good** 
There is a medium level of latency between players. There will be a medium amount of input delay.

 **Latency Mode - (7 - 9) - Default**
There is a high latency between players. You will notice a significant input delay.  This is the games default behavior. 

Special thanks to @Belonit for his work on this.

### Ranked matches
Latency modes will never go beyond mode 4, keeping input delay to a minimum.  
For online custom lobbies, there will be no restriction on the mode it will pick.