### PR TITLE
Feature/net7

### DIFF
--- a/package/CnCNetYRLauncher.sh
+++ b/package/CnCNetYRLauncher.sh
@@ -1,2 +1,3 @@
 #!/bin/sh
+cd "$(dirname "$0")"
 dotnet Resources/Binaries/UniversalGL/clientogl.dll "$@"

--- a/package/Resources/yr-wine.sh
+++ b/package/Resources/yr-wine.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-wine gamemd-spawn.exe $*
+${WINE:=wine} gamemd-spawn.exe $*


### PR DESCRIPTION
I made a few changes:

- `package/Resources/yr-wine.sh` - Allow to override the WINE binary (for example: when you installed Origin / EA App using Lutris and you have to use the Lutris wine-binary)
- `package/CnCNetYRLauncher.sh` - Make sure that you change directory to the directory where the `CnCNetYRLauncher.sh` script is located, before starting the yr-client (`clientogl.dll`) itself. This because of the relative path that if provided to `dotnet` to start the yr-client (`clientogl.dll`) with (this will fail if you're not in the same directory as the `CnCNetYRLauncher.sh` script itself).