### PR TITLE
Add Auto Repair option

### DIFF
--- a/package/INI/Game Options/Auto Repair.ini
+++ b/package/INI/Game Options/Auto Repair.ini
@@ -1,0 +1,2 @@
+[IQ]
+RepairSell=0

--- a/package/Resources/MultiplayerGameLobby.ini
+++ b/package/Resources/MultiplayerGameLobby.ini
@@ -467,7 +467,7 @@ $Y=getBottom(chkNoSpy) + GAME_OPTION_GAP
 CustomIniPath=INI\Game Options\Auto Repair.ini
 Checked=False
 ToolTip=Buildings will be repaired automatically
-Text=Auto Repair
+Text=Auto Repair Buildings
 $X=getX(chkNoDogEngiEat)
 $Y=getBottom(chkNoDogEngiEat) + GAME_OPTION_GAP
 

--- a/package/Resources/MultiplayerGameLobby.ini
+++ b/package/Resources/MultiplayerGameLobby.ini
@@ -191,6 +191,7 @@ $CC-GO19=chkNoSpawnPreviews:GameLobbyCheckBox
 $CC-GO20=chkNoYuriNoFrance:GameLobbyCheckBox
 $CC-GO21=chkNoSpy:GameLobbyCheckBox
 $CC-GO06=chkNoDogEngiEat:GameLobbyCheckBox
+$CC-GO22=chkAutoRepair:GameLobbyCheckBox
 
 $CC01=BtnSaveLoadGameOptions:XNAClientButton
 
@@ -293,7 +294,7 @@ $Y=getBottom(chkShortGame) + GAME_OPTION_GAP
 
 [chkCrates]
 SpawnIniOption=Crates
-Checked=Flase
+Checked=False
 ToolTip=Random Power-Up Crates will appear.
 Text=Crates Appear
 $X=getX(chkRedeplMCV)
@@ -461,6 +462,14 @@ ToolTip=Dogs will be unable to kill Engineers.
 Text=No Dog Engineer Kills
 $X=getX(chkNoSpy)
 $Y=getBottom(chkNoSpy) + GAME_OPTION_GAP
+
+[chkAutoRepair]
+CustomIniPath=INI\Game Options\Auto Repair.ini
+Checked=False
+ToolTip=Buildings will be repaired automatically
+Text=Auto Repair
+$X=getX(chkNoDogEngiEat)
+$Y=getBottom(chkNoDogEngiEat) + GAME_OPTION_GAP
 
 [btnCnCNet]
 Location=0,0


### PR DESCRIPTION
Adds the ability to enable or disable autorepair

useful for maps like:
- Survival
- Rekool
- OIL

To reduce the micromanagement on repairing stuff


![image](https://github.com/user-attachments/assets/236eb6e3-d181-40a8-8321-1c5b1fb75e88)

