### PR TITLE
Fix Brutal AI

### DIFF
--- a/package/INI/Game Options/Brutal AI.ini
+++ b/package/INI/Game Options/Brutal AI.ini
@@ -24,7 +24,7 @@ HelipadLimit=2
 AirstripRatio=.12
 AirstripLimit=0
 BaseSizeAdd=10;6
-AIBaseSpacing=1;2
+AIBaseSpacing=2
 AttackInterval=0.2
 AttackDelay=0.4;0.2
 MaximumBaseDefenseValue=100
@@ -305,26 +305,6 @@ AntiInfantryValue=15
 AIBuildThis=yes
 [NADEPT]
 AIBuildThis=yes
-
-;WantsExtraSpace=yes adds +1 to AIBaseSpacing
-[GAWEAP]
-WantsExtraSpace=yes
-[NAWEAP]
-WantsExtraSpace=yes
-[YAWEAP]
-WantsExtraSpace=yes
-[GAPILE]
-WantsExtraSpace=yes
-[NAHAND]
-WantsExtraSpace=yes
-[YABRCK]
-WantsExtraSpace=yes
-[GAREFN]
-WantsExtraSpace=yes
-[NAREFN]
-WantsExtraSpace=yes
-[YAREFN]
-WantsExtraSpace=yes
 
 ; AI Buildings
 [RAZER-GAWEAP0]


### PR DESCRIPTION
WantsExtraSpace on structures is causing interference in maps with too limited build space. 

Reverting back to baseplanning of 2 fixes it.