### PR TITLE
Fix cannot launch campaign from a legit CD installation

### DIFF
--- a/package/Resources/Allied Theme/ExtrasWindow.ini
+++ b/package/Resources/Allied Theme/ExtrasWindow.ini
@@ -15,7 +15,7 @@ ForeColor=230,230,230
 FontIndex=1
 TextColorIdle=230,230,230
 TextColorHover=255,255,255
-URL=game.exe
+URL=ra2.exe
 
 [btnYRCampaign]
 Location=645,241
@@ -27,7 +27,7 @@ ForeColor=230,230,230
 FontIndex=1
 TextColorIdle=230,230,230
 TextColorHover=255,255,255
-URL=gamemd.exe
+URL=ra2md.exe
 
 [btnExCancel]
 Location=645,535

--- a/package/Resources/Soviet Theme/ExtrasWindow.ini
+++ b/package/Resources/Soviet Theme/ExtrasWindow.ini
@@ -15,7 +15,7 @@ ForeColor=255,255,0
 FontIndex=1
 TextColorIdle=255,255,0
 TextColorHover=255,255,0
-URL=game.exe
+URL=ra2.exe
 
 [btnYRCampaign]
 Location=645,241
@@ -27,7 +27,7 @@ ForeColor=255,255,0
 FontIndex=1
 TextColorIdle=255,255,0
 TextColorHover=255,255,0
-URL=gamemd.exe
+URL=ra2md.exe
 
 [btnExCancel]
 Location=645,535

--- a/package/Resources/Yuri Theme/ExtrasWindow.ini
+++ b/package/Resources/Yuri Theme/ExtrasWindow.ini
@@ -15,7 +15,7 @@ ForeColor=255,255,0
 FontIndex=1
 TextColorIdle=255,255,0
 TextColorHover=255,255,0
-URL=game.exe
+URL=ra2.exe
 
 [btnYRCampaign]
 Location=645,241
@@ -27,7 +27,7 @@ ForeColor=255,255,0
 FontIndex=1
 TextColorIdle=255,255,0
 TextColorHover=255,255,0
-URL=gamemd.exe
+URL=ra2md.exe
 
 [btnExCancel]
 Location=645,535


### PR DESCRIPTION
launching from `game(md).exe` requires a hack. The legit CD version does not come with it 

![图片](https://github.com/user-attachments/assets/ac6f2377-2e35-480d-9743-182646f23330)

Steam version comes with ra2.exe and ra2md.exe. No yuri.exe included.

CD version comes with the 3 exe above. Clicking game(md).exe won't launch the game
