### PR TITLE
Add CnC-DDraw (stretch)

### DIFF
--- a/package/Resources/Renderers.ini
+++ b/package/Resources/Renderers.ini
@@ -14,6 +14,7 @@
 9=OpenGL
 10=TS_DDRAW_OLD
 11=IE_DDRAW
+12=CNC_DDRAW_stretch
 
 ; Specifies the default renderers for different operating systems.
 [DefaultRenderer]
@@ -64,6 +65,18 @@ UIName=CnC-DDraw
 DLLName=cnc-ddraw.dll
 ConfigFileName=ddraw.ini
 ResConfigFileName=cnc-ddraw.ini
+WindowedModeSection=ddraw
+WindowedModeKey=windowed
+BorderlessWindowedModeKey=border
+IsBorderlessWindowedModeKeyReversed=true
+UseQres=false
+
+; same as CNC_DDRAW, but always stretch to fullscreen
+[CNC_DDRAW_stretch]
+UIName=CnC-DDraw (stretch)
+DLLName=cnc-ddraw.dll
+ConfigFileName=ddraw.ini
+ResConfigFileName=cnc-ddraw-stretch.ini; same with "cnc-ddraw.ini" except for "fullscreen=true"
 WindowedModeSection=ddraw
 WindowedModeKey=windowed
 BorderlessWindowedModeKey=border

--- a/package/Resources/Renderers.ini
+++ b/package/Resources/Renderers.ini
@@ -4,17 +4,17 @@
 [Renderers]
 0=Default
 1=CNC_DDRAW
-2=TS_DDRAW
-3=GDI
-4=DDWrapper
-5=DxWnd
-6=Software
-7=Nazoul_DDRAW
-8=DDRAWCompat
-9=OpenGL
-10=TS_DDRAW_OLD
-11=IE_DDRAW
-12=CNC_DDRAW_stretch
+2=CNC_DDRAW_stretch
+3=TS_DDRAW
+4=GDI
+5=DDWrapper
+6=DxWnd
+7=Software
+8=Nazoul_DDRAW
+9=DDRAWCompat
+10=OpenGL
+11=TS_DDRAW_OLD
+12=IE_DDRAW
 
 ; Specifies the default renderers for different operating systems.
 [DefaultRenderer]

--- a/package/Resources/cnc-ddraw-stretch.ini
+++ b/package/Resources/cnc-ddraw-stretch.ini
@@ -1,0 +1,1733 @@
+; cnc-ddraw - https://github.com/FunkyFr3sh/cnc-ddraw
+
+[ddraw]
+; ### Optional settings ###
+; Use the following settings to adjust the look and feel to your liking
+
+
+; Stretch to custom resolution, 0 = defaults to the size game requests
+width=0
+height=0
+
+; Override the width/height settings shown above and always stretch to fullscreen
+; Note: Can be combined with 'windowed=true' to get windowed-fullscreen aka borderless mode
+fullscreen=true
+
+; Run in windowed mode rather than going fullscreen
+windowed=false
+
+; Maintain aspect ratio
+maintas=false
+
+; Use custom aspect ratio - Example values: 4:3, 16:10, 16:9, 21:9
+aspect_ratio=
+
+; Windowboxing / Integer Scaling
+boxing=false
+
+; Real rendering rate, -1 = screen rate, 0 = unlimited, n = cap
+; Note: Does not have an impact on the game speed, to limit your game speed use 'maxgameticks='
+maxfps=-1
+
+; Vertical synchronization, enable if you get tearing - (Requires 'renderer=auto/opengl*/direct3d9*')
+; Note: vsync=true can fix tearing but it will cause input lag
+vsync=false
+
+; Automatic mouse sensitivity scaling
+; Note: Only works if stretching is enabled. Sensitivity will be adjusted according to the size of the window
+adjmouse=true
+
+; Preliminary libretro shader support - (Requires 'renderer=opengl*') https://github.com/libretro/glsl-shaders
+; 2x scaling example: https://imgur.com/a/kxsM1oY - 4x scaling example: https://imgur.com/a/wjrhpFV
+; You can specify a full path to a .glsl shader file here or use one of the values listed below
+; Possible values: Nearest neighbor, Bilinear, Bicubic, Lanczos, xBR-lv2
+shader=Shaders\interpolation\catmull-rom-bilinear.glsl
+
+; Window position, -32000 = center to screen
+posX=-32000
+posY=-32000
+
+; Renderer, possible values: auto, opengl, openglcore, gdi, direct3d9, direct3d9on12 (auto = try direct3d9/opengl, fallback = gdi)
+renderer=auto
+
+; Developer mode (don't lock the cursor)
+devmode=false
+
+; Show window borders in windowed mode
+border=true
+
+; Save window position/size/state on game exit and restore it automatically on next game start
+; Possible values: 0 = disabled, 1 = save to global 'ddraw' section, 2 = save to game specific section
+savesettings=1
+
+; Should the window be resizable by the user in windowed mode?
+resizable=true
+
+; Upscaling filter for the direct3d9* renderers
+; Possible values: 0 = nearest-neighbor, 1 = bilinear, 2 = bicubic, 3 = lanczos (bicubic/lanczos only support 16/32bit color depth games)
+d3d9_filter=2
+
+; Disable font smoothing for fonts that are smaller than size X
+anti_aliased_fonts_min_size=13
+
+; Raise the size of small fonts to X
+min_font_size=0
+
+; Center window to screen when game changes the display resolution
+; Possible values: 0 = never center, 1 = automatic, 2 = always center
+center_window=1
+
+; Inject a custom display resolution into the in-game resolution list - Example values: 960x540, 3840x2160
+; Note: This setting can used for downscaling as well, you can insert resolutions higher than your monitor supports
+inject_resolution=
+
+; Enable upscale hack for high resolution patches (Supports C&C1, Red Alert 1, Worms 2 and KKND Xtreme)
+vhack=false
+
+; Where should screenshots be saved
+screenshotdir=.\Screenshots\
+
+; Switch between windowed/borderless modes with alt+enter rather than windowed/fullscreen modes
+toggle_borderless=false
+
+; Switch between windowed/fullscreen upscaled modes with alt+enter rather than windowed/fullscreen modes
+toggle_upscaled=false
+
+
+
+; ### Compatibility settings ###
+; Use the following settings in case there are any issues with the game
+
+
+; Hide WM_ACTIVATEAPP and WM_NCACTIVATE messages to prevent problems on alt+tab
+noactivateapp=false
+
+; Max game ticks per second, possible values: -1 = disabled, -2 = refresh rate, 0 = emulate 60hz vblank, 1-1000 = custom game speed
+; Note: Can be used to slow down a too fast running game, fix flickering or too fast animations
+; Note: Usually one of the following values will work: 60 / 30 / 25 / 20 / 15 (lower value = slower game speed)
+maxgameticks=0
+
+; Method that should be used to limit game ticks (maxgameticks=): 0 = Automatic, 1 = TestCooperativeLevel, 2 = BltFast, 3 = Unlock, 4 = PeekMessage
+limiter_type=0
+
+; Force minimum FPS, possible values: 0 = disabled, -1 = use 'maxfps=' value, -2 = same as -1 but force full redraw, 1-1000 = custom FPS
+; Note: Set this to a low value such as 5 or 10 if some parts of the game are not being displayed (e.g. menus or loading screens)
+minfps=0
+
+; Disable fullscreen-exclusive mode for the direct3d9*/opengl* renderers
+; Note: Can be used in case some GUI elements like buttons/textboxes/videos/etc.. are invisible
+nonexclusive=true
+
+; Force CPU0 affinity, avoids crashes/freezing, *might* have a performance impact
+; Note: Disable this if the game is not running smooth or there are sound issues
+singlecpu=true
+
+; Available display resolutions, possible values: 0 = Small list, 1 = Very small list, 2 = Full list
+; Note: Set this to 2 if your chosen resolution is not working or does not show up in the list
+; Note: Set this to 1 if the game is crashing on startup
+resolutions=0
+
+; Child window handling, possible values: 0 = Disabled, 1 = Display top left, 2 = Display top left + repaint, 3 = Hide, 4 = Display top left + hide
+; Note: Disables upscaling if a child window was detected (to ensure the game is fully playable, may look weird though)
+fixchilds=2
+
+; Enable the following setting if your cursor doesn't lock to the window or it doesn't work properly when upscaling is enabled
+hook_peekmessage=false
+
+
+; Undocumented compatibility settings - These will probably not solve your problem, you should rather focus on the settings above
+fix_alt_key_stuck=false
+game_handles_close=false
+fix_not_responding=false
+no_compat_warning=false
+guard_lines=200
+max_resolutions=0
+lock_surfaces=false
+flipclear=false
+rgb555=false
+no_dinput_hook=false
+center_cursor_fix=false
+;fake_mode=640x480x32
+lock_mouse_top_left=false
+;win_version=95
+hook=4
+limit_gdi_handles=false
+remove_menu=false
+refresh_rate=0
+
+
+
+; ### Hotkeys ###
+; Use the following settings to configure your hotkeys, 0x00 = disabled
+; Virtual-Key Codes: https://docs.microsoft.com/en-us/windows/win32/inputdev/virtual-key-codes
+
+
+; Switch between windowed and fullscreen mode = [Alt] + ???
+keytogglefullscreen=0x0D
+
+; Switch between windowed and fullscreen mode (single key) = ???
+keytogglefullscreen2=0x00
+
+; Maximize window = [Alt] + ???
+keytogglemaximize=0x22
+
+; Maximize window (single key) = ???
+keytogglemaximize2=0x00
+
+; Unlock cursor 1 = [Ctrl] + ???
+keyunlockcursor1=0x09
+
+; Unlock cursor 2 = [Right Alt] + ???
+keyunlockcursor2=0xA3
+
+; Screenshot
+keyscreenshot=0x2C
+
+
+
+; ### Config program settings ###
+; The following settings are for cnc-ddraw config.exe
+
+
+; cnc-ddraw config program language, possible values: auto, english, chinese, german, spanish, russian, hungarian, french, italian, vietnamese
+configlang=auto
+
+; cnc-ddraw config program theme, possible values: Windows10, Cobalt XEMedia
+configtheme=Windows10
+
+; Hide the 'Compatibility Settings' tab in cnc-ddraw config
+hide_compat_tab=false
+
+; Allow the users to 'Restore default settings' via cnc-ddraw config
+allow_reset=true
+
+
+
+; ### Game specific settings ###
+; The following settings override all settings shown above, section name = executable name
+
+
+; 7th Legion
+[legion]
+maxgameticks=25
+singlecpu=false
+
+; Atrox
+[Atrox]
+nonexclusive=true
+
+; Atomic Bomberman
+[BM]
+maxgameticks=60
+
+; Age of Empires
+[empires]
+nonexclusive=true
+adjmouse=true
+resolutions=2
+
+; Age of Empires: The Rise of Rome
+[empiresx]
+nonexclusive=true
+adjmouse=true
+resolutions=2
+
+; Age of Empires: The Rise of Rome (RockNRor patch)
+[EmpiresX_RockNRor]
+nonexclusive=true
+adjmouse=true
+resolutions=2
+
+; Age of Empires II
+[EMPIRES2]
+nonexclusive=true
+adjmouse=true
+
+; Age of Empires II: The Conquerors
+[age2_x1]
+nonexclusive=true
+adjmouse=true
+
+; Abomination - The Nemesis Project
+[abomb]
+singlecpu=false
+
+; American Conquest / Cossacks
+[DMCR]
+resolutions=2
+guard_lines=300
+minfps=-2
+
+; American Girls Dress Designer
+[Dress Designer]
+fake_mode=640x480x32
+nonexclusive=true
+
+; Age of Wonders
+[AoW]
+resolutions=2
+nonexclusive=false
+singlecpu=false
+
+; Age of Wonders
+[AoWCompat]
+resolutions=2
+nonexclusive=false
+singlecpu=false
+
+; Age of Wonders Config Tool
+[AoWSetup]
+resolutions=2
+
+; Age of Wonders 2
+[AoW2]
+resolutions=2
+nonexclusive=false
+singlecpu=false
+
+; Age of Wonders 2
+[AoW2Compat]
+resolutions=2
+nonexclusive=false
+singlecpu=false
+
+; Age of Wonders 2 Config Tool
+[aow2Setup]
+resolutions=2
+
+; Age of Wonders: Shadow Magic
+[AoWSM]
+resolutions=2
+nonexclusive=false
+singlecpu=false
+
+; Age of Wonders: Shadow Magic
+[AoWSMCompat]
+resolutions=2
+nonexclusive=false
+singlecpu=false
+
+; Age of Wonders: Shadow Magic Config Tool
+[AoWSMSetup]
+resolutions=2
+
+; Anstoss 3
+[anstoss3]
+renderer=gdi
+adjmouse=true
+
+; Anno 1602
+[1602]
+adjmouse=true
+
+; Army Men: World War / Army Men: Operation Meltdown
+[amww]
+maxfps=60
+maxgameticks=120
+minfps=-1
+
+; Army Men: Air Tactics
+[Amat]
+maxfps=60
+maxgameticks=120
+minfps=-1
+
+; Army Men: Toys in Space
+[ARMYMENTIS]
+maxfps=60
+maxgameticks=120
+minfps=-1
+
+; Army Men 2
+[ArmyMen2]
+maxfps=60
+maxgameticks=120
+minfps=-1
+
+; Alien Nations
+[AN]
+adjmouse=true
+
+; Another War
+[AnotherWar]
+singlecpu=false
+
+; Atlantis
+[ATLANTIS]
+renderer=opengl
+maxgameticks=60
+center_cursor_fix=true
+
+; Airline Tycoon Deluxe
+[AT]
+lock_mouse_top_left=true
+fixchilds=3
+
+; Arthur's Wilderness Rescue
+[Arthur]
+renderer=gdi
+
+; Axis & Allies
+[AxisAllies]
+hook_peekmessage=true
+maxgameticks=60
+
+; A Bug's Life Action Game
+[bugs]
+fix_not_responding=true
+
+; Barney - Secret of the Rainbow
+[Barney]
+adjmouse=false
+width=0
+height=0
+resizable=false
+maintas=false
+boxing=false
+
+; Baldur's Gate II
+; Note: 'Use 3D Acceleration' must be disabled and 'Full Screen' must be enabled in BGConfig.exe
+[BGMain]
+resolutions=2
+
+; Balls of Steel v1.2
+[bos]
+checkfile=.\barbarin.ddp
+win_version=95
+
+; BALDR FORCE EXE
+[BaldrForce]
+noactivateapp=true
+
+; Blade & Sword
+[comeon]
+maxgameticks=60
+fixchilds=3
+
+; Blood II - The Chosen / Shogo - Mobile Armor Division
+[Client]
+checkfile=.\SOUND.REZ
+noactivateapp=true
+
+; Blue's 123 Time Activities
+[Blues123Time]
+renderer=gdi
+hook=3
+
+; Blue's Treasure Hunt
+[Blue'sTreasureHunt-Disc1]
+renderer=gdi
+
+; Blue's Treasure Hunt
+[Blue'sTreasureHunt-Disc2]
+renderer=gdi
+
+; Blue's Reading Time Activities
+[Blue's Reading Time]
+renderer=gdi
+
+; Blue's ArtTime Activities
+[ArtTime]
+renderer=gdi
+
+; Callus 95 - CPS-1 (Capcom Play System 1) emulator
+[CALLUS95]
+game_handles_close=true
+windowed=true
+toggle_borderless=true
+devmode=true
+
+; Callus 95 - CPS-1 (Capcom Play System 1) emulator
+[CALLUS95p]
+game_handles_close=true
+windowed=true
+toggle_borderless=true
+devmode=true
+
+; Carmageddon
+[CARMA95]
+flipclear=true
+carma95_hack=true
+
+; Carmageddon
+[CARM95]
+flipclear=true
+carma95_hack=true
+
+; Carmen Sandiego's Great Chase - NOT WORKING YET
+[TIME32]
+renderer=gdi
+adjmouse=false
+width=0
+height=0
+resizable=false
+maintas=false
+boxing=false
+
+; Captain Claw
+[claw]
+adjmouse=true
+noactivateapp=true
+nonexclusive=true
+
+; Championship Manager 99-00
+[cm9900]
+singlecpu=false
+
+; Command & Conquer: Sole Survivor
+[SOLE]
+maxgameticks=120
+maxfps=60
+minfps=-1
+
+; Command & Conquer Gold - CnCNet
+[cnc95]
+maxfps=125
+
+; Command & Conquer Gold
+[C&C95]
+maxgameticks=120
+maxfps=60
+minfps=-1
+
+; Command & Conquer: Red Alert - CnCNet
+[ra95-spawn]
+maxfps=125
+
+; Command & Conquer: Red Alert
+[ra95]
+maxgameticks=120
+maxfps=60
+minfps=-1
+
+; Command & Conquer: Red Alert
+[ra95_Mod-Launcher]
+maxgameticks=120
+maxfps=60
+minfps=-1
+
+; Command & Conquer: Red Alert
+[ra95p]
+maxfps=60
+minfps=-1
+
+; Command & Conquer: Tiberian Sun / Command & Conquer: Red Alert 2
+[game]
+nonexclusive=false
+checkfile=.\blowfish.dll
+tshack=true
+noactivateapp=true
+adjmouse=true
+maxfps=60
+minfps=-1
+maintas=false
+boxing=false
+
+; Command & Conquer: Tiberian Sun Demo
+[SUN]
+nonexclusive=false
+noactivateapp=true
+tshack=true
+adjmouse=true
+maxfps=60
+minfps=-1
+maintas=false
+boxing=false
+
+; Command & Conquer: Tiberian Sun - CnCNet
+[ts-spawn]
+nonexclusive=false
+noactivateapp=true
+tshack=true
+adjmouse=true
+maxfps=60
+minfps=-1
+maintas=false
+boxing=false
+
+; Command & Conquer: Red Alert 2 - XWIS
+[ra2]
+nonexclusive=false
+noactivateapp=true
+tshack=true
+maxfps=60
+minfps=-1
+maintas=false
+boxing=false
+
+; Command & Conquer: Red Alert 2 - XWIS
+[Red Alert 2]
+nonexclusive=false
+noactivateapp=true
+tshack=true
+maxfps=60
+minfps=-1
+maintas=false
+boxing=false
+
+; Command & Conquer: Red Alert 2: Yuri's Revenge
+[gamemd]
+nonexclusive=false
+noactivateapp=true
+tshack=true
+maxfps=60
+minfps=-1
+maintas=false
+boxing=false
+
+; Command & Conquer: Red Alert 2: Yuri's Revenge - ?ModExe?
+[ra2md]
+nonexclusive=false
+noactivateapp=true
+tshack=true
+maxfps=60
+minfps=-1
+maintas=false
+boxing=false
+
+; Command & Conquer: Red Alert 2: Yuri's Revenge - CnCNet
+[gamemd-spawn]
+nonexclusive=false
+noactivateapp=true
+tshack=true
+maxfps=60
+minfps=-1
+maintas=false
+boxing=false
+
+; Command & Conquer: Red Alert 2: Yuri's Revenge - XWIS
+[Yuri's Revenge]
+nonexclusive=false
+noactivateapp=true
+tshack=true
+maxfps=60
+minfps=-1
+maintas=false
+boxing=false
+
+; Commandos
+[comandos]
+maxgameticks=-1
+
+; Commandos
+[comandos_w10]
+maxgameticks=-1
+
+; Constructor
+[Game_W95]
+noactivateapp=true
+
+; Caesar III
+[c3]
+nonexclusive=true
+adjmouse=true
+
+; Chris Sawyer's Locomotion
+[LOCO/2]
+checkfile=.\LOCO.EXE
+adjmouse=true
+
+; Cultures 2
+[Cultures2]
+adjmouse=true
+
+; Cultures 2 MP
+[Cultures2MP]
+adjmouse=true
+
+; Close Combat 2: A Bridge Too Far
+[cc2]
+adjmouse=true
+nonexclusive=true
+
+; Close Combat 3: The Russian Front
+[cc3]
+adjmouse=true
+nonexclusive=true
+
+; Close Combat 4: The Battle of the Bulge
+[cc4]
+adjmouse=true
+nonexclusive=true
+
+; Close Combat 5: Invasion: Normandy
+[cc5]
+adjmouse=true
+nonexclusive=true
+
+; ClueFinders Math Adventures 1.0
+[TCFM32]
+adjmouse=false
+width=0
+height=0
+resizable=false
+maintas=false
+boxing=false
+
+; ClueFinders Math Adventures 1.0
+[cfmath32]
+adjmouse=false
+width=0
+height=0
+resizable=false
+maintas=false
+boxing=false
+
+; Call To Power 2
+[ctp2]
+maintas=false
+boxing=false
+
+; Corsairs Gold
+[corsairs]
+adjmouse=true
+
+; Divine Divinity
+[div]
+resolutions=2
+singlecpu=false
+
+; Die by the Sword
+[windie]
+maxgameticks=30
+
+; Dragon Throne: Battle of Red Cliffs
+[AdSanguo]
+maxgameticks=60
+noactivateapp=true
+limiter_type=2
+
+; Dark Reign: The Future of War
+[DKReign]
+maxgameticks=60
+
+; Dungeon Keeper 2
+[DKII]
+maxgameticks=60
+noactivateapp=true
+
+; Dreams to Realty
+[windream]
+maxgameticks=60
+
+; Deadlock 2
+[DEADLOCK]
+fixchilds=0
+adjmouse=false
+maintas=false
+boxing=false
+
+; Diablo
+[Diablo]
+devmode=true
+
+; Diablo: Hellfire
+[hellfire]
+devmode=true
+
+; Disney Trivia Challenge
+[DisneyTr]
+fixchilds=3
+lock_mouse_top_left=true
+renderer=gdi
+
+; Discoworld Noir
+[dn]
+fake_mode=640x480x16
+
+; Dominion - Storm Over Gift 3
+[dominion]
+flipclear=true
+
+; Excalibur 2555AD
+[_FISH]
+singlecpu=false
+
+; Escape Velocity Nova
+[EV Nova]
+nonexclusive=true
+hook_peekmessage=true
+rgb555=true
+keytogglefullscreen=0x46
+adjmouse=true
+
+; Economic War
+[EcoW]
+maxgameticks=60
+fix_not_responding=true
+
+; Emperor: Rise of the Middle Kingdom
+[Emperor]
+nonexclusive=true
+adjmouse=true
+
+; Enemy Infestation
+[EI]
+hook_peekmessage=true
+
+; F-16 Agressor
+[f-16]
+resolutions=1
+
+; Fable
+[FABLE]
+singlecpu=false
+
+; Fallout Tactics: Brotherhood of Steel
+[BOS/2]
+checkfile=.\binkw32.dll
+hook_peekmessage=true
+
+; Fallout Tactics: Brotherhood of Steel
+[BOS_HR]
+hook_peekmessage=true
+
+; Fallout Tactics: Brotherhood of Steel
+[FT Tools]
+hook_peekmessage=true
+
+; Falcon 4.0 (Microprose version)
+[falcon4]
+singlecpu=false
+
+; Flight Simulator 98
+[FLTSIM95]
+flightsim98_hack=true
+
+; Flight Simulator 98
+[FLTSIM98]
+flightsim98_hack=true
+
+; Fairy Tale About Father Frost, Ivan and Nastya
+[mrazik]
+guard_lines=0
+
+; Final Liberation: Warhammer Epic 40000
+[Epic40k]
+hook_peekmessage=true
+maxgameticks=125
+
+; Future Cop - L.A.P.D.
+[FCopLAPD]
+nonexclusive=true
+adjmouse=true
+
+; Freddi 1
+[Freddi1]
+renderer=gdi
+
+; Freddi Fish : The Case of the Hogfish Rustlers of Briny Gulch
+[Freddihrbg]
+renderer=gdi
+
+; Freddi Water Worries
+[Water]
+renderer=gdi
+
+; Freddi Fish
+[FreddiSCS]
+renderer=gdi
+
+; Freddi Fish
+[FREDDI4]
+renderer=gdi
+hook=3
+
+; Freddi Fish's One-Stop Fun Shop
+[FreddisFunShop]
+renderer=gdi
+
+; Freddi Fish: The Case of the Creature of Coral Cove
+[freddicove]
+renderer=gdi
+
+; Freddi Fish: The Case of the Haunted Schoolhouse
+[FreddiCHSH]
+renderer=gdi
+
+; Freddi Fish: Maze Madness
+[Maze]
+renderer=gdi
+
+; Glover
+[glover]
+fix_not_responding=true
+
+; G-Police
+[GPOLICE]
+maxgameticks=60
+singlecpu=false
+
+; Gangsters: Organized Crime
+[gangsters]
+adjmouse=true
+nonexclusive=true
+fixchilds=0
+fake_mode=640x480x8
+
+; Grand Theft Auto
+[Grand Theft Auto]
+singlecpu=false
+
+; Grand Theft Auto: London 1969
+[gta_uk]
+singlecpu=false
+
+; Grand Theft Auto: London 1961
+[Gta_61]
+singlecpu=false
+
+; Gruntz
+[GRUNTZ]
+adjmouse=true
+noactivateapp=true
+nonexclusive=true
+
+; Girl Talk
+[GirlTalk]
+resolutions=2
+game_handles_close=true
+
+; Jazz Jackrabbit 2 plus
+[Jazz2]
+inject_resolution=800x450
+
+; Jazz Jackrabbit 2
+[Jazz2_NonPlus]
+inject_resolution=800x450
+
+; Jungle Storm
+[Jstorm]
+no_compat_warning=true
+win_version=98
+
+; Hades Challenge
+[HADESCH]
+no_compat_warning=true
+
+; Heroes of Might and Magic II:  The Succession Wars
+[HEROES2W]
+adjmouse=true
+
+; Heroes of Might and Magic III
+[Heroes3]
+renderer=opengl
+game_handles_close=true
+keytogglefullscreen2=0x73
+
+; Heroes of Might and Magic III HD Mod
+[Heroes3 HD]
+renderer=opengl
+game_handles_close=true
+keytogglefullscreen2=0x73
+
+; Heroes of Might and Magic III - Master of Puppets mod
+[MoP]
+game_handles_close=true
+keytogglefullscreen2=0x73
+
+; Heroes of Might and Magic IV
+[heroes4]
+remove_menu=true
+keytogglefullscreen2=0x73
+
+; Hard Truck: Road to Victory
+[htruck]
+maxgameticks=25
+renderer=opengl
+noactivateapp=true
+
+; Hooligans: Storm over Europe
+[hooligans]
+limit_gdi_handles=true
+
+; Imperialism 2: The Age of Exploration
+[Imperialism II]
+adjmouse=false
+width=0
+height=0
+resizable=false
+maintas=false
+boxing=false
+
+; Icewind Dale 2
+; Note: 'Full Screen' must be enabled in Config.exe
+; Note: 1070x602 is the lowest possible 16:9 resolution for the Widescreen patch (600/601 height will crash)
+[iwd2]
+resolutions=2
+inject_resolution=1070x602
+
+; Invictus
+[Invictus]
+adjmouse=true
+renderer=opengl
+
+; Interstate 76
+[i76]
+adjmouse=true
+
+; Infantry
+[infantry]
+resolutions=2
+infantryhack=true
+max_resolutions=90
+
+; Infantry Steam
+[FreeInfantry]
+resolutions=2
+infantryhack=true
+max_resolutions=90
+
+; Jagged Alliance 2
+[ja2]
+singlecpu=false
+sirtech_hack=true
+fix_alt_key_stuck=true
+
+; Jagged Alliance 2: Unfinished Business
+[JA2UB]
+singlecpu=false
+sirtech_hack=true
+fix_alt_key_stuck=true
+
+; Jagged Alliance 2: Wildfire
+[WF6]
+singlecpu=false
+sirtech_hack=true
+fix_alt_key_stuck=true
+
+; Jagged Alliance 2 - UC mod
+[JA2_UC]
+singlecpu=false
+sirtech_hack=true
+fix_alt_key_stuck=true
+
+; Jagged Alliance 2 - Vengeance Reloaded mod
+[JA2_Vengeance]
+singlecpu=false
+sirtech_hack=true
+fix_alt_key_stuck=true
+
+; Jeopardy! - NOT WORKING YET
+[jeoppc]
+singlecpu=false
+
+; Karma Immortal Wrath
+[karma]
+fix_not_responding=true
+maxgameticks=60
+limiter_type=4
+
+; Konung
+[konung]
+fixchilds=0
+
+; Konung 2
+[Konung2]
+fixchilds=0
+
+; KKND Xtreme (With high resolution patch)
+[KKNDgame]
+vhack=true
+
+; KKND2: Krossfire
+[KKND2]
+noactivateapp=true
+
+; Knights and Merchants The Shattered Kingdom
+[KaM_800]
+limiter_type=2
+maxgameticks=60
+
+; Knights and Merchants The Shattered Kingdom
+[KaM_1024]
+limiter_type=2
+maxgameticks=60
+
+; Lode Runner 2
+[LR2]
+no_dinput_hook=true
+fake_mode=640x480x16
+
+; Last Bronx
+[LB]
+maxgameticks=30
+
+; Lapis (lapis.mgame.com)
+[Lapis]
+fixchilds=3
+lock_mouse_top_left=true
+
+; LEGO LOCO - NOT WORKING YET
+[LOCO]
+checkfile=.\LEGO.INI
+fake_mode=1024x768x16
+posX=0
+posY=0
+border=false
+fullscreen=false
+
+; Little Bear Kindergarten/Preschool Thinking Adventures: Parent's Progress Report
+[LBPR]
+adjmouse=false
+width=0
+height=0
+resizable=false
+maintas=false
+boxing=false
+
+; Little Bear Kindergarten/Preschool Thinking Adventures
+[LBSTART]
+adjmouse=false
+width=0
+height=0
+resizable=false
+maintas=false
+boxing=false
+
+; Little Bear Toddler Discovery Adventures
+[LBT]
+adjmouse=false
+width=0
+height=0
+resizable=false
+maintas=false
+boxing=false
+
+; Lionheart
+[Lionheart]
+hook_peekmessage=true
+
+; Links Extreme
+[EXTREME]
+singlecpu=false
+
+; Lost Vikings 2
+[LOSTV95]
+fake_mode=320x240x16
+
+; Nightmare Creatures
+[NC]
+maxgameticks=30
+singlecpu=false
+
+; Moto Racer (software mode)
+[moto]
+maxgameticks=59
+
+; Madeline 1st Grade Math
+[madmath1]
+nonexclusive=true
+no_compat_warning=true
+adjmouse=false
+width=0
+height=0
+resizable=false
+maintas=false
+boxing=false
+renderer=gdi
+hook=2
+win_version=nt4
+
+; Madeline 1st Grade Math: Progress Report
+[madpr]
+nonexclusive=true
+no_compat_warning=true
+adjmouse=false
+width=0
+height=0
+resizable=false
+maintas=false
+boxing=false
+renderer=gdi
+hook=2
+win_version=nt4
+
+; Madeline 2nd Grade Math
+[madmath2]
+nonexclusive=true
+no_compat_warning=true
+adjmouse=false
+width=0
+height=0
+resizable=false
+maintas=false
+boxing=false
+renderer=gdi
+hook=2
+win_version=nt4
+
+; Majesty Gold
+[Majesty]
+minfps=-2
+
+; Majesty Gold HD
+[MajestyHD]
+adjmouse=true
+
+; Majesty Gold HD
+[MajestyHD - Old]
+adjmouse=true
+
+; Mech Warrior 3
+[Mech3]
+nonexclusive=true
+
+; Moorhuhn 2
+[Moorhuhn2]
+fix_alt_key_stuck=true
+
+; Metal Knight
+[mk]
+maxgameticks=60
+limiter_type=4
+
+; New Robinson
+[ROBY]
+adjmouse=true
+hook_peekmessage=true
+
+; Neo Sonic Universe
+[nsu]
+fake_mode=320x240x32
+
+; Neo Sonic Universe - battle mode
+[nsu_battle]
+fake_mode=320x240x32
+
+; Nancy Drew (All games)
+[Game/3]
+checkfile=.\Nancy.cid
+limiter_type=1
+maxgameticks=120
+
+; NBA Full Court Press
+[NBA_FCP]
+fake_mode=640x480x8
+
+; Nox
+[NOX]
+checkfile=.\NOX.ICD
+renderer=direct3d9
+nonexclusive=false
+windowed=false
+maxgameticks=125
+
+; Nox Reloaded
+[NoxReloaded]
+maxgameticks=125
+
+; Nox GOG
+[Game/2]
+checkfile=.\nox.cfg
+maxgameticks=125
+
+; Outlaws
+[olwin]
+noactivateapp=true
+maxgameticks=60
+adjmouse=true
+renderer=gdi
+
+; Pandora's Box Puzzle Game
+[Pandora]
+fixchilds=0
+
+; Paddle Bash Hotshot
+[SPAGHSPaddle]
+no_compat_warning=true
+
+; Pajama Sam's Games to Play on Any Day
+[PJGAMES]
+renderer=gdi
+
+; Pajama Sam
+[PajamaTAL]
+renderer=gdi
+
+; Pajama Sam: No Need to Hide When It's Dark Outside
+[PajamaNHD]
+renderer=gdi
+
+; Pajama Sam 3
+[Pajama3]
+renderer=gdi
+
+; Pajama Sam's One-Stop Fun Shop
+[SamsFunShop]
+renderer=gdi
+
+; Pajama Sam DON'T FEAR THE DARK
+[pjSam]
+renderer=gdi
+
+; Pajama Sam 3: You Are What You Eat From Your Head To Your Feet
+[UKpajamaEAT]
+renderer=gdi
+
+; Pharaoh
+[Pharaoh]
+adjmouse=true
+
+; Putt-Putt Saves The Zoo
+[PUTTZOO]
+renderer=gdi
+hook=3
+
+; Putt-Putt's One-Stop Fun Shop
+[PuttsFunShop]
+renderer=gdi
+
+; Putt-Putt and Pep's Dog On A Stick
+[DOG]
+renderer=gdi
+
+; Putt-Putt Joins the Circus
+[puttcircus]
+renderer=gdi
+
+; Putt-Putt Enters The Race
+[UKPuttRace]
+renderer=gdi
+
+; Putt-Putt: Travels Through Time
+[PuttTTT]
+renderer=gdi
+
+; Putt-Putt and Pep's Balloon-o-Rama
+[Balloon]
+renderer=gdi
+
+; Putt-Putt Travels Through Time
+[PUTTPUTTTTT]
+renderer=gdi
+
+; Putt-Putt Joins the Circus
+[puttputtjtc]
+renderer=gdi
+
+; Pizza Syndicate
+[Pizza2]
+renderer=opengl
+
+; Pizza Syndicate - Mehr Biss (Mission CD)
+[Pizza_Mission]
+renderer=opengl
+
+; Pax Imperia
+[Pax Imperia]
+nonexclusive=true
+
+; Panzer Dragoon
+[PANZERDG]
+singlecpu=false
+
+; Play with the Teletubbies
+[PlayWTT]
+hook=3
+
+; Populous - The Beginning
+[popTB]
+singlecpu=false
+
+; Rage of Mages
+[rom]
+maxgameticks=60
+limiter_type=4
+singlecpu=true
+
+; Railroad Tycoon II
+[RT2]
+maxgameticks=60adjmouse=true
+
+; Reader Rabbit Thinking Ages 4-6 (US)
+[rrta32]
+adjmouse=false
+width=0
+height=0
+resizable=false
+maintas=false
+boxing=false
+
+; Reader Rabbit Reading Ages 4-6
+[rrirjw32]
+renderer=gdi
+adjmouse=false
+width=0
+height=0
+resizable=false
+maintas=false
+boxing=false
+
+; Reader Rabbit Reading Ages 6-9
+[irj2w32]
+renderer=gdi
+adjmouse=false
+width=0
+height=0
+resizable=false
+maintas=false
+boxing=false
+
+; Real War
+[RealWar]
+maxgameticks=60
+limiter_type=3
+
+; Return to Krondor
+[RtK]
+fixchilds=3
+lock_mouse_top_left=true
+singlecpu=false
+limiter_type=2
+game_handles_close=true
+maxgameticks=59
+anti_aliased_fonts_min_size=99
+
+; Rent-A-Hero
+[Rent-A-Hero]
+singlecpu=false
+
+; ROAD RASH
+[RoadRash]
+adjmouse=true
+nonexclusive=true
+
+; Rising Lands (patched)
+[Rising]
+singlecpu=false
+
+; Robin Hood - The Legend of Sherwood (GOG)
+[Game/4]
+checkfile=.\Robin Hood.exe
+singlecpu=false
+fix_not_responding=true
+
+; Roland Garros 98 (software mode)
+[rg98]
+singlecpu=false
+
+; Robin Hood - The Legend of Sherwood (Steam)
+[_rh]
+singlecpu=false
+fix_not_responding=true
+
+; Robin Hood - The Legend of Sherwood
+[Robin Hood]
+singlecpu=false
+fix_not_responding=true
+
+; Scooby-Doo(TM), Case File #1 The Glowing Bug Man - NOT WORKING YET
+[Case File #1]
+windowed=true
+nonexclusive=true
+fake_mode=640x480x32
+
+; Seven Kingdoms II
+[7k2]
+fake_mode=352x240x32
+fix_not_responding=true
+
+; Swarog
+[Swarog]
+singlecpu=false
+maxfps=60
+maxgameticks=60
+minfps=-1
+
+; Sim Copter
+[SimCopter]
+nonexclusive=true
+
+; Settlers 3
+[s3]
+nonexclusive=true
+
+; Star Trek - Armada
+[Armada]
+armadahack=true
+nonexclusive=true
+adjmouse=true
+maintas=false
+boxing=false
+
+; Star Wars Rebellion
+[REBEXE]
+adjmouse=false
+width=0
+height=0
+resizable=false
+maintas=false
+boxing=false
+
+; Star Wars: Galactic Battlegrounds
+[battlegrounds]
+nonexclusive=true
+adjmouse=true
+
+; Star Wars: Galactic Battlegrounds: Clone Campaigns
+[battlegrounds_x1]
+nonexclusive=true
+adjmouse=true
+
+; Starcraft
+[StarCraft]
+game_handles_close=true
+
+; Space Rangers
+[Rangers]
+hook_peekmessage=true
+
+; SPYFox: Hold the Mustard
+[mustard]
+renderer=gdi
+
+; SPY Fox: Some Assembly Required
+[Spyfox2]
+renderer=gdi
+
+; SPY Fox in Dry Cereal (2008)
+[SpyFox]
+renderer=gdi
+
+; SPY Fox in Dry Cereal (2001)
+[SPYFOXDC]
+renderer=gdi
+
+; SPY Fox : Some Assembly Required
+[SPYFOXSR]
+renderer=gdi
+
+; SPY Fox: Operation Ozone
+[spyozon]
+renderer=gdi
+
+; SPY Fox: Operation Ozone
+[spyfoxozu]
+renderer=gdi
+
+; Stronghold Crusader HD
+[Stronghold Crusader]
+resolutions=2
+stronghold_hack=true
+adjmouse=true
+
+; Stronghold Crusader Extreme HD
+[Stronghold_Crusader_Extreme]
+resolutions=2
+stronghold_hack=true
+adjmouse=true
+
+; Stronghold HD
+[Stronghold]
+resolutions=2
+stronghold_hack=true
+adjmouse=true
+
+; Sim City 3000
+[SC3]
+minfps=-2
+maxgameticks=60
+; Shadow Watch
+[sw]
+adjmouse=true
+maxgameticks=30
+; Shadow Flare
+[ShadowFlare]
+nonexclusive=true
+adjmouse=true
+
+; Squad Leader
+[SquadLeader]
+maxgameticks=30
+limiter_type=4
+
+; Soldiers At War
+[SAW_Game]
+maxgameticks=30
+limiter_type=4
+
+; The Curse Of Monkey Island
+[COMI]
+singlecpu=false
+
+; The Tone Rebellion
+[Float]
+hook_peekmessage=true
+
+; Total Annihilation (Unofficial Beta Patch v3.9.02)
+[TotalA]
+max_resolutions=32
+lock_surfaces=true
+singlecpu=false
+
+; Total Annihilation Replay Viewer (Unofficial Beta Patch v3.9.02)
+[Viewer]
+max_resolutions=32
+lock_surfaces=true
+singlecpu=false
+
+; Virtual Springfield
+[VIRTUAL]
+game_handles_close=true
+singlecpu=false
+
+; Total Annihilation: Kingdoms
+[Kingdoms]
+game_handles_close=true
+max_resolutions=32
+
+; The Missing on Lost Island
+[Island]
+lock_mouse_top_left=true
+fixchilds=3
+
+; The Neverhood
+[nhc]
+singlecpu=false
+
+; The X-Files DVD
+[XFiles]
+windowed=true
+fullscreen=true
+toggle_borderless=true
+
+; The Learning Company Launcher
+[TLCLauncher]
+tlc_hack=true
+adjmouse=false
+width=0
+height=0
+resizable=false
+maintas=false
+boxing=false
+
+; The Jungle Book Groove Party
+[Jungle_vr]
+fix_not_responding=true
+
+; Three Kingdoms: Fate of the Dragon
+[sanguo]
+maxgameticks=60
+noactivateapp=true
+limiter_type=2
+
+; Thomas & Friends - The Great Festival Adventure
+[Thomas]
+no_compat_warning=true
+noactivateapp=true
+
+; RollerCoaster Tycoon
+[rct]
+no_dinput_hook=true
+singlecpu=false
+maxfps=0
+adjmouse=true
+
+; Twisted Metal
+[TWISTED]
+nonexclusive=true
+maxgameticks=25
+minfps=5
+
+; Twisted Metal 2
+[Tm2]
+nonexclusive=true
+maxgameticks=60
+adjmouse=true
+fixchilds=1
+maintas=false
+boxing=false
+
+; Tzar: The Burden of the Crown
+; Note: Must set 'DIRECTXDEVICE=0' in 'Tzar.ini'
+[Tzar]
+adjmouse=true
+
+; Unreal
+[Unreal]
+adjmouse=false
+lock_mouse_top_left=true
+center_cursor_fix=true
+
+; Uprising
+[uprising]
+adjmouse=true
+
+; Uprising 2
+[Uprising 2]
+renderer=opengl
+adjmouse=true
+
+; Unreal
+[Unreal]
+noactivateapp=true
+
+; Vermeer
+[vermeer]
+adjmouse=true
+fake_mode=640x480x32
+
+; Virtua Fighter 2
+[VF2]
+fake_mode=640x480x8
+
+; Wall Street Trader 2000 - NOT WORKING YET
+[WSTrader]
+nonexclusive=false
+windowed=false
+
+; WarCraft 2000: Nuclear Epidemic
+[war2000]
+resolutions=2
+guard_lines=600
+minfps=-2
+
+; Warhammer 40000: Chaos Gate
+[WH40K]
+maxgameticks=250
+
+; Weird War
+[WeirdWar]
+singlecpu=false
+
+; Wizardry 8
+[Wiz8]
+sirtech_hack=true
+fix_alt_key_stuck=true
+
+; Worms 2
+[worms2]
+vhack=true
+flipclear=true
+game_handles_close=true
+center_cursor_fix=true
+
+; Worms Armageddon
+[WA]
+lock_mouse_top_left=true
+
+; Wheel Of Fortune
+[WHEEL]
+singlecpu=false
+
+; War Wind
+[WW]
+minfps=-1
+
+; Jeff Wayne's 'The War Of The Worlds'
+[WoW]
+singlecpu=false
+minfps=-1
+
+; Zeus and Poseidon
+[Zeus]
+adjmouse=true
+
+; Zork Nemesis
+[znemesis]
+fix_not_responding=true
+singlecpu=false
+maxgameticks=60
+limiter_type=4
+


### PR DESCRIPTION
CnC-DDraw supports 4 kinds of fullscreen/windowed mode.
![图片](https://github.com/user-attachments/assets/80824bae-d01c-432c-a39f-db6498b76e5f)

Currently, only "Fullscreen" and "Windowed" modes are provided.
However, both are painful for QHD monitor users -- they tend to choose a lower in-game resolution as almost nobody wants to play the game with a high-density resolution. And it turns out:
- the windowed mode comes without upscaling
- the fullscreen mode changes the resolution during the game, making windows resize and repositioning other windows. Even worse, such behavior will probably cause that partial gaming area is unclickable: when the user clicks partial area in the game, another window or the taskbar may get clicked, and the game minimizes itself.

Hence, it's necessary to bring support for other two modes, "Fullscreen upscaled" and "Borderless". Both way stretches the game to desktop resolution -- avoiding changing the resolution reduces so much pains. The former mode still make the game in full screen mode, while the latter mode fakes a fullscreen experience with a borderless window.

To apply one of these two modes, select "CnC-DDraw (stretch)" renderer with "Windowed Mode" option on for "Fullscreen upscaled", off for "Borderless".

-------

Chinese online platforms have been providing these two modes for years and it turns out these two modes are **necessary** for a proportion of players. Recently, Discord user JackieJayhawk also reported his/her experience on the necessity of these two modes.

![图片](https://github.com/user-attachments/assets/4dafa978-21c0-4632-aaaa-beee0e8a4d91)

![图片](https://github.com/user-attachments/assets/29387c12-57d2-459e-9207-aefb3ed080e0)
