### PR TITLE
Fix Mirages going invisible on Mount Rushmore

### DIFF
--- a/package/Maps/Yuri's Revenge/mountmoras.map
+++ b/package/Maps/Yuri's Revenge/mountmoras.map
@@ -1,5 +1,5 @@
 [General]
-DefaultMirageDisguises=TREE20,TREE21,TREE22,TREE23, TREE24
+DefaultMirageDisguises=TREE20,TREE21,TREE22,TREE23,TREE24
 
 [GAYARD]
 Name=Allied Shipyard


### PR DESCRIPTION
Mirages were going invisible when disguised, due to a space before TREE24.