### PR TITLE
Add click sound to the `btnLaunchGame` button

### DIFF
--- a/package/Resources/GameLobbyBase.ini
+++ b/package/Resources/GameLobbyBase.ini
@@ -240,6 +240,7 @@ Location=12,0
 DistanceFromBottomBorder=13
 Text=Launch Game
 Size=133,23
+ClickSoundEffect=button.wav
 
 [btnLeaveGame]
 Text=Leave Game


### PR DESCRIPTION
My teammates constantly have a problem that they can not understand if `I'm Ready` button has clicked or not due to the IRC ping. I suggest that adding a click sound will help them and other people.