### PR TITLE
Add required files

### DIFF
--- a/package/Resources/ClientDefinitions.ini
+++ b/package/Resources/ClientDefinitions.ini
@@ -14,6 +14,7 @@ MPMapsPath=INI\MPMaps.ini
 LoadingScreenCount=0
 LongGameName=Yuri's Revenge
 LocalGame=YR
+RequiredFiles=gamemd.exe,ra2.mix,ra2md.mix,langmd.mix,language.mix,theme.mix,thememd.mix,BINKW32.DLL,Blowfish.dll
 RegistryInstallPath=YurisRevenge
 CnCNetLiveStatusIdentifier=cncnet5_yr
 CreditsURL=http://www.moddb.com/mods/the-dawn-of-the-tiberium-age/tutorials/credits


### PR DESCRIPTION
Partially solves an issue when player could install client in the folder without RA2YR files.

![image](https://github.com/user-attachments/assets/d098cf9a-a5bd-42aa-a0cf-b4afcf082d4c)
