### PR TITLE
fix disable SW

### DIFF
--- a/package/INI/Game Options/SuperWeapons/Defensive.ini
+++ b/package/INI/Game Options/SuperWeapons/Defensive.ini
@@ -2,13 +2,16 @@
 TechLevel=-1
 AIBuildThis=no
 BuildLimit=0
+SuperWeapon=none
 
 [GAWEAT]
 TechLevel=-1
 AIBuildThis=no
 BuildLimit=0
+SuperWeapon=none
 
 [YAPPET]
 TechLevel=-1
 AIBuildThis=no
 BuildLimit=0
+SuperWeapon=none

--- a/package/INI/Game Options/SuperWeapons/Disabled.ini
+++ b/package/INI/Game Options/SuperWeapons/Disabled.ini
@@ -2,31 +2,37 @@
 TechLevel=-1
 AIBuildThis=no
 BuildLimit=0
+SuperWeapon=none
 
 [GACSPH]
 TechLevel=-1
 AIBuildThis=no
 BuildLimit=0
+SuperWeapon=none
 
 [YAGNTC]
 TechLevel=-1
 AIBuildThis=no
 BuildLimit=0
+SuperWeapon=none
 
 [NAMISL]
 TechLevel=-1
 AIBuildThis=no
 BuildLimit=0
+SuperWeapon=none
 
 [GAWEAT]
 TechLevel=-1
 AIBuildThis=no
 BuildLimit=0
+SuperWeapon=none
 
 [YAPPET]
 TechLevel=-1
 AIBuildThis=no
 BuildLimit=0
+SuperWeapon=none
 
 [GATECH]
 SuperWeapon=none

--- a/package/INI/Game Options/SuperWeapons/Offensive.ini
+++ b/package/INI/Game Options/SuperWeapons/Offensive.ini
@@ -2,13 +2,16 @@
 TechLevel=-1
 AIBuildThis=no
 BuildLimit=0
+SuperWeapon=none
 
 [GACSPH]
 TechLevel=-1
 AIBuildThis=no
 BuildLimit=0
+SuperWeapon=none
 
 [YAGNTC]
 TechLevel=-1
 AIBuildThis=no
 BuildLimit=0
+SuperWeapon=none


### PR DESCRIPTION
Disable SW 

Expectation:
If SW is disabled, SW should not be operationl

Actual:
SW are operational if captured.

Existing logic only prevented building the SW but did not consider capturing neutral SW on the map

Fix:
Disable SW