### PR TITLE
Remove hardcoded size of [GameCreationWindow]

### DIFF
--- a/package/Resources/Allied Theme/GameCreationWindow.ini
+++ b/package/Resources/Allied Theme/GameCreationWindow.ini
@@ -14,5 +14,4 @@ BasedOn=GenericWindow.ini
 [GameCreationWindow]
 DrawMode=Stretched
 DrawBorders=true
-Size=493,194
 BackgroundTexture=ModalBG.png

--- a/package/Resources/GenericWindow.ini
+++ b/package/Resources/GenericWindow.ini
@@ -150,7 +150,6 @@ BackgroundTexture=ModalBG.png
 
 [GameCreationWindow_Advanced]
 DrawBorders=false
-Size=493,424
 
 [LANGameCreationWindow]
 DrawMode=Tiled

--- a/package/Resources/GenericWindowLegacy.ini
+++ b/package/Resources/GenericWindowLegacy.ini
@@ -156,7 +156,6 @@ BackgroundTexture=ModalBG.png
 
 [GameCreationWindow_Advanced]
 DrawBorders=false
-Size=493,424
 
 [LANGameCreationWindow]
 DrawMode=Tiled

--- a/package/Resources/Soviet Theme/GameCreationWindow.ini
+++ b/package/Resources/Soviet Theme/GameCreationWindow.ini
@@ -14,5 +14,4 @@ BasedOn=GenericWindow.ini
 [GameCreationWindow]
 DrawMode=Stretched
 DrawBorders=true
-Size=493,194
 BackgroundTexture=ModalBG.png


### PR DESCRIPTION
Postfix after https://github.com/CnCNet/cncnet-yr-client-package/pull/531 ( https://github.com/CnCNet/xna-cncnet-client/pull/772 This PR allows modders NOT defining the size of the GameCreationWindow. )

Affects only the soviet and allied themes

Before:

![图片](https://github.com/user-attachments/assets/2cf95fba-ec16-467a-9b48-15ed162d5703)

After:

![图片](https://github.com/user-attachments/assets/71206b92-4d6a-4f32-9067-f6bea756b2a3)
