### PR TITLE
Fix a bug that made elite flak trooper weaker than veteran and weaker than non-promoted at all

### DIFF
--- a/package/spawner.xdp
+++ b/package/spawner.xdp
@@ -24741,7 +24741,7 @@ Anim=GUNFIRE
 Burst=2
 
 [FlakGuyAAGunE]	; Separate from Flak Cannon weapon so that stats may be tweaked
-Damage=8
+Damage=20 ; changed on jul 2025. previous value of 8 made the elite unit weaker than the non-promoted one
 ROF=25
 Range=8
 Projectile=FlakProj	; AA bullet shared with Flak Cannon

--- a/package/spawner2.xdp
+++ b/package/spawner2.xdp
@@ -17684,7 +17684,7 @@ Anim=GUNFIRE
 Burst=2
 
 [FlakGuyAAGunE]	; Separate from Flak Cannon weapon so that stats may be tweaked
-Damage=8
+Damage=20 ; changed on jul 2025. previous value of 8 made the elite unit weaker than the non-promoted one
 ROF=25
 Range=8
 Projectile=FlakProj	; AA bullet shared with Flak Cannon


### PR DESCRIPTION
This issue is known. There is a video on YouTube with visual examples of this bug. I checked everything several times, the bug was confirmed.
I set a new parameter for Elite weapon: damage=20 , which is identical to the parameter of the non-elite corresponding weapon [FlakGuyAAGun].
I conducted tests with the new parameter:
The elite Flak Trooper became slightly more effective than the veteran.
The difference between a non-promoted unit and a veteran is much more than the difference between a veteran and an Elite Flak Trooper with the new parameter.

This pull request solves #298