### PR TITLE
Fixing a bug with Yuri Prime for the RA2 mode, when it could control 10 units instead of 1. And reducing the range from 30 to 25

### DIFF
--- a/package/spawner2.xdp
+++ b/package/spawner2.xdp
@@ -17231,9 +17231,9 @@ Anim=YURICNTL
 FireOnce=yes
 
 [SuperMindControl]
-Damage=10;Needed to be considered offensive unit
+Damage=1 ; changed on Jul 2025. With the previous parameter value of 10, Yuri Prime could control 10 units instead of 1
 ROF=200
-Range=30
+Range=25 ; changed on Jul 2025. The previous value of 30 seemed absolutely excessive
 Projectile=PsychicControl
 Speed=100
 Warhead=Controller


### PR DESCRIPTION
I've been using these parameters in my mod maps for a long time. This fixes the bug and works without any issues.
As for the range, I also use the parameter value of 25 for Oceania, which is a 200x200 naval map. Yuri Prime looks like an absolutely overpowered unit even with a range of 25. 25 is the range of an aircraft carrier and a dreadnought, nothing else in the game shoots further.
I can't imagine how this unit can operate on smaller maps. It will simply be able to capture any unit anywhere on the map. 25 is the maximum imaginable and the lower limit of absurdity. 30 (the standard value) is already much further than the limit of absurdity.

This pull request solves #296