### PR TITLE
In RA2 mode, you won't need to hold down Ctrl to attack camouflaged units (Mirages, Spies)

### DIFF
--- a/package/spawner2.xdp
+++ b/package/spawner2.xdp
@@ -263,7 +263,7 @@ AlliedDisguise=E1
 SovietDisguise=E2 ; these are the defaults for the spy if a MakeupKit hasn't been used
 SpyPowerBlackout=1000 ; Frame time a spy shuts down power for (900 = 1 minute)
 SpyMoneyStealPercent=.5 ; Percent of total money you take with a spy
-AttackCursorOnDisguise=no ;gs If yes, the mouse will be an attack cursor on a disguised unit as if he is not disguised.  
+AttackCursorOnDisguise=yes ; changed on Jul 2025 from no ;gs If yes, the mouse will be an attack cursor on a disguised unit as if he is not disguised.  
 								;If no, you will still get an attack cursor on a fake-blinking Mirage and a spy _always_
 
 ; SJM: Default disguise for the Mirage Tank (object type)


### PR DESCRIPTION
This is the default in YR. It is very inconvenient to change this habit when playing in different modes of RA2 and YR. In addition, Ctrl is the only button that does not allow playing RA2 exclusively with a mouse. Removing this barrier will allow playing on a tablet, playing for disabled people with 1 hand, and with a broken keyboard, lying in bed, only with a mouse. These are rare cases, but you must agree, the ability to play in principle only with a mouse is a global factor, and the obstacle to this ability is only 1 button in a certain situation.
In addition, this brings 2 games to a single standard.
I see only advantages here and no disadvantages.