### PR TITLE
Fixing a bug with Yuri Prime for the RA2 mode, when it could control 10 units instead of 1

### DIFF
--- a/package/spawner2.xdp
+++ b/package/spawner2.xdp
@@ -17231,7 +17231,7 @@ Anim=YURICNTL
 FireOnce=yes
 
 [SuperMindControl]
-Damage=10;Needed to be considered offensive unit
+Damage=1 ; Changed on Jul 2025 from 10. This solved the problem when Yuri Prime could control 10 units instead of 1
 ROF=200
 Range=30
 Projectile=PsychicControl


### PR DESCRIPTION
I've been using these parameters in my mod maps for a long time. This fixes the bug and works without any issues.

This pull request solves #296