### PR TITLE
Restore missing refinery smoke animation in RA2 mode

### DIFF
--- a/package/spawner2.xdp
+++ b/package/spawner2.xdp
@@ -8671,11 +8671,17 @@ ThreatPosed=0	; This value MUST be 0 for all building addons
 DamageSmokeOffset=410, 100, 165
 AIBuildThis=yes
 TogglePower=no
-RefnSmokeOffsetOne=-92, -208, 312
-RefnSmokeOffsetTwo=-92, 208, 312
+;RefnSmokeOffsetOne=-92, -208, 312
+;RefnSmokeOffsetTwo=-92, 208, 312
 Spyable=yes
 ;WantsExtraSpace=yes ; gs This will look for a space AIBaseSpacing+1 when the computer places, but will settle for AIBasSpacing
 NumberImpassableRows=3 ; This is the fix to the Repair depots are flat and RadioContact/Enter means I can drive on you assumption.  It counts from game west
+; next added on Jul 2025
+RefinerySmokeOffsetOne=-92, -172, 312
+RefinerySmokeOffsetTwo=-92, 164, 312
+RefinerySmokeFrames=50
+RefinerySmokeParticleSystem=SmallGreySSys
+ResourceDestination=yes
 
 ; Ore Refinery
 [NAREFN]
@@ -8713,10 +8719,16 @@ DamageParticleSystems=SparkSys,SmallGreySSys,BigGreySmokeSys
 DamageSmokeOffset=410, 100, 165
 AIBuildThis=yes
 TogglePower=no
-RefnSmokeOffsetOne=-80, -232, 372
-RefnSmokeOffsetTwo=-80, 232, 372
+;RefnSmokeOffsetOne=-80, -232, 372
+;RefnSmokeOffsetTwo=-80, 232, 372
 Spyable=yes
 ;WantsExtraSpace=yes ; gs This will look for a space AIBaseSpacing+1 when the computer places, but will settle for AIBasSpacing
+; next added on Jul 2025
+RefinerySmokeOffsetOne=-80, -226, 380
+RefinerySmokeOffsetTwo=-80, 204, 380
+RefinerySmokeFrames=50
+RefinerySmokeParticleSystem=SmallGreySSys
+ResourceDestination=yes
 
 ;Allied Ore Purifier
 [GAOREP]

--- a/package/spawner2.xdp
+++ b/package/spawner2.xdp
@@ -8681,7 +8681,6 @@ RefinerySmokeOffsetOne=-92, -172, 312
 RefinerySmokeOffsetTwo=-92, 164, 312
 RefinerySmokeFrames=50
 RefinerySmokeParticleSystem=SmallGreySSys
-ResourceDestination=yes
 
 ; Ore Refinery
 [NAREFN]
@@ -8728,7 +8727,6 @@ RefinerySmokeOffsetOne=-80, -226, 380
 RefinerySmokeOffsetTwo=-80, 204, 380
 RefinerySmokeFrames=50
 RefinerySmokeParticleSystem=SmallGreySSys
-ResourceDestination=yes
 
 ;Allied Ore Purifier
 [GAOREP]

--- a/package/spawner2.xdp
+++ b/package/spawner2.xdp
@@ -8678,7 +8678,7 @@ Spyable=yes
 NumberImpassableRows=3 ; This is the fix to the Repair depots are flat and RadioContact/Enter means I can drive on you assumption.  It counts from game west
 ; next added on Jul 2025
 RefinerySmokeOffsetOne=-92, -172, 312
-RefinerySmokeOffsetTwo=-92, 164, 312
+RefinerySmokeOffsetTwo=-92, 168, 312
 RefinerySmokeFrames=50
 RefinerySmokeParticleSystem=SmallGreySSys
 
@@ -8724,7 +8724,7 @@ Spyable=yes
 ;WantsExtraSpace=yes ; gs This will look for a space AIBaseSpacing+1 when the computer places, but will settle for AIBasSpacing
 ; next added on Jul 2025
 RefinerySmokeOffsetOne=-80, -226, 380
-RefinerySmokeOffsetTwo=-80, 204, 380
+RefinerySmokeOffsetTwo=-80, 200, 380
 RefinerySmokeFrames=50
 RefinerySmokeParticleSystem=SmallGreySSys
 


### PR DESCRIPTION
In RA2 mode, the refinery animation is missing. This restores it.