### PR TITLE
Fix bug when Spy tries but fails to disguise as Terror Drone

### DIFF
--- a/package/spawner.xdp
+++ b/package/spawner.xdp
@@ -27471,7 +27471,7 @@ ProneDamage=150%
 
 ;Takes picture for disguise
 [Snapshot]
-Verses=100%,100%,100%,0%,0%,0%,0%,0%,0%,100%,100%
+Verses=100%,100%,100%,0%,0%,0%,0%,0%,0%,0%,0%
 MakesDisguise=yes
 
 [TankSnapshot]

--- a/package/spawner2.xdp
+++ b/package/spawner2.xdp
@@ -19835,7 +19835,7 @@ ProneDamage=150%
 
 ;Takes picture for disguise
 [Snapshot]
-Verses=100%,100%,100%,0%,0%,0%,0%,0%,0%,100%,100%
+Verses=100%,100%,100%,0%,0%,0%,0%,0%,0%,0%,0%
 MakesDisguise=yes
 
 [TankSnapshot]


### PR DESCRIPTION
During the masking attempt, the masking sounds are played. However, no masking occurs.
a small problem but it's an obvious bug.
Why do we need it?