### PR TITLE
Update updateexec

### DIFF
--- a/package/updateexec
+++ b/package/updateexec
@@ -520,6 +520,7 @@ Maps\Yuri's Revenge\blitz_park_of_vytautas_blitz.map
 Maps\Yuri's Revenge\blitz_park_of_vytautas_blitz.png
 INI\Game Options\No_France_No_Yuri.ini
 INI\ForcedOptions ReadMe.txt
+Maps\Custom\83b65056362a027b56ce57842588d1e470373af3.png
 
 [DeleteFolder]
 Maps\Yuri's Revenge\CTF


### PR DESCRIPTION
removed bigass map preview of lost lake that was overriding the smaller preview of lost lake (bigass map preview was overloading and crashing the client upon hosting)