### PR TITLE
Remove RAZER maps from preupdateexec

### DIFF
--- a/package/preupdateexec
+++ b/package/preupdateexec
@@ -25,22 +25,6 @@ wcrate.sno
 wcrate.tem
 wcrate.ubn
 wcrate.urb
-Maps\Yuri's Revenge\Survival\2_hard_survival_RAZER.map
-Maps\Yuri's Revenge\Survival\2_hard_survival_RAZER.png
-Maps\Yuri's Revenge\Survival\2_liberty_island_RAZER.map
-Maps\Yuri's Revenge\Survival\2_liberty_island_RAZER.png
-Maps\Yuri's Revenge\Survival\2_survival_in_razadonia_RAZER.map
-Maps\Yuri's Revenge\Survival\2_survival_in_razadonia_RAZER.png
-Maps\Yuri's Revenge\Survival\2_the_chrono_surprise_RAZER.map
-Maps\Yuri's Revenge\Survival\2_the_chrono_surprise_RAZER.png
-Maps\Yuri's Revenge\Survival\3_cliffs_of_pandemonium_RAZER.map
-Maps\Yuri's Revenge\Survival\3_cliffs_of_pandemonium_RAZER.png
-Maps\Yuri's Revenge\Survival\4_show_down_arena_RAZER.map
-Maps\Yuri's Revenge\Survival\4_show_down_arena_RAZER.png
-Maps\Yuri's Revenge\Survival\4_symmetrical_survival_v1_RAZER.map
-Maps\Yuri's Revenge\Survival\4_symmetrical_survival_v1_RAZER.png
-Maps\Yuri's Revenge\Survival\4_symmetrical_survival_v2_RAZER.map
-Maps\Yuri's Revenge\Survival\4_symmetrical_survival_v2_RAZER.png
 Resources\Binaries\Windows\Rampastring.Tools.dll
 Resources\Binaries\XNA\Rampastring.Tools.dll
 Resources\Binaries\OpenGL\Rampastring.Tools.dll


### PR DESCRIPTION
This solves issue #528 

Note however, if someone is updating from a very old version, they could have the map files with RAZER and razer at the sametime.