### PR TITLE
Stop different files warning when going from beta to live

### DIFF
--- a/package/updateexec
+++ b/package/updateexec
@@ -515,6 +515,7 @@ Maps\Yuri's Revenge\blitz_park_of_vytautas_blitz.png
 INI\Game Options\No_France_No_Yuri.ini
 INI\ForcedOptions ReadMe.txt
 Maps\Custom\83b65056362a027b56ce57842588d1e470373af3.png
+INI\Game Options\AI\Extreme AI Beta.ini
 
 [DeleteFolder]
 Maps\Yuri's Revenge\CTF


### PR DESCRIPTION
Deletes `Extreme AI Beta.ini` included inside beta client when switching back to live client.