### PR TITLE
Change the font index in game in progress window from 3 to 0

### DIFF
--- a/package/Resources/Allied Theme/GameInProgressWindow.ini
+++ b/package/Resources/Allied Theme/GameInProgressWindow.ini
@@ -22,11 +22,11 @@ BackgroundTexture=WarningWindowBG.png
 [Warning]
 Location=90,32
 Text=!WARNING!
-FontIndex=3
+FontIndex=0
 RemapColor=255,0,0
 
 [Warning2]
 Location=90,84
 Text=!WARNING!
-FontIndex=3
+FontIndex=0
 RemapColor=255,0,0

--- a/package/Resources/Soviet Theme/GameInProgressWindow.ini
+++ b/package/Resources/Soviet Theme/GameInProgressWindow.ini
@@ -22,11 +22,11 @@ BackgroundTexture=WarningWindowBG.png
 [Warning]
 Location=90,32
 Text=!WARNING!
-FontIndex=3
+FontIndex=0
 RemapColor=255,0,0
 
 [Warning2]
 Location=90,84
 Text=!WARNING!
-FontIndex=3
+FontIndex=0
 RemapColor=255,0,0


### PR DESCRIPTION
Left: before this PR. Right: after this PR

<img width="1174" height="313" alt="599433cf-3c3c-4e46-8bed-c776879b8896" src="https://github.com/user-attachments/assets/282ef7dc-146a-40e1-9220-061a3850e357" />

Fonts 0 and 1 are most frequently used. Font 2 and 4 seems never been used. Font 3 is used only here and the map briefing (the map briefing font needs a change in the client https://github.com/CnCNet/xna-cncnet-client/pull/823). I see no advantage of using font 3 since it just looks like font 0. Moreover, a universal font takes more than 10 MB so it's better to avoid duplicating the font just being able to serve as font 2, 3, 4