### PR TITLE
Return missing SPEED bonus animation in RA2

### DIFF
--- a/package/artra2.ini
+++ b/package/artra2.ini
@@ -11728,6 +11728,10 @@ Rate=400
 Normalized=yes
 Rate=400
 
+[SPEED]
+Normalized=yes
+Rate=400
+
 [MLTIMISL]
 Normalized=yes
 Rate=400


### PR DESCRIPTION
There is currently no animation when receiving the corresponding bonus from the crate.
This brings it back.