### PR TITLE
Restore Map Sort Button

### DIFF
--- a/package/Resources/GameLobbyBase.ini
+++ b/package/Resources/GameLobbyBase.ini
@@ -138,12 +138,12 @@ $Y=getY(lbMapList) - getHeight($Self) - EMPTY_SPACE_TOP
 
 [lblGameModeSelect]
 Text=GAME MODE:
-$X=getX(ddGameMode) - getWidth($Self) - LABEL_SPACING
+$X=getX(ddGameMode) - getWidth($Self) - 35
 $Y=getY(ddGameMode) + 1
 
 [btnMapSortAlphabetically]
-Visible=false
-Enabled=false
+Visible=true
+Enabled=true
 
 [btnLaunchGame]
 Text=Launch Game


### PR DESCRIPTION
Accidently left out in last UI refactor. This restores it.

<img width="650" height="818" alt="image" src="https://github.com/user-attachments/assets/5ca38af6-a568-4e3c-82d5-c79210526b0e" />
