### PR TITLE
Fix OccupyHeight values for CAAIRP in artra2.ini and artyr.ini

### DIFF
--- a/package/artra2.ini
+++ b/package/artra2.ini
@@ -2076,6 +2076,9 @@ ActiveAnimTwo=CAAIRP_F
 ActiveAnimTwoZAdjust=-100
 ActiveAnimTwoYSort=362
 ActiveAnimTwoPowered=no
+OccupyHeight=2
+AddOccupy1=-2,0
+AddOccupy2=-1,1
 DamageFireOffset0=-3,5
 DamageFireOffset1=-65,32
 

--- a/package/artyr.ini
+++ b/package/artyr.ini
@@ -3478,6 +3478,9 @@ ActiveAnimTwo=CAAIRP_F
 ActiveAnimTwoZAdjust=-100
 ActiveAnimTwoYSort=362
 ActiveAnimTwoPowered=no
+OccupyHeight=2
+AddOccupy1=-2,0
+AddOccupy2=-1,1
 DamageFireOffset0=-3,5
 DamageFireOffset1=-65,32
 


### PR DESCRIPTION
Now these values ​​are missing, which leads to the default value, which is equal to the height parameter.
The result is not very good:

<img width="425" height="268" alt="image" src="https://github.com/user-attachments/assets/75ad067f-e02d-4664-92a8-642a286a7ef8" />

After the fix, as it should be:

<img width="428" height="237" alt="image" src="https://github.com/user-attachments/assets/2f63192a-af2c-44e5-b491-93b997c8f2a0" />
