### PR TITLE
Make `btnDisplayAdvancedOptions` use the same texture as `Create Game`

### DIFF
--- a/package/Resources/GameCreationWindow.ini
+++ b/package/Resources/GameCreationWindow.ini
@@ -1,3 +1,7 @@
 [btnLoadGame]
 Visible=false
 Enabled=false
+
+[btnDisplayAdvancedOptions]
+IdleTexture=133pxbtn.png
+HoverTexture=133pxbtn_c.png


### PR DESCRIPTION
Before:

<img width="660" height="339" alt="image" src="https://github.com/user-attachments/assets/e156e061-4919-41a3-b060-7dde4b1a5dfa" />

After:

<img width="661" height="329" alt="image" src="https://github.com/user-attachments/assets/36550368-110b-471c-8cc1-fa86201ec377" />
