### PR TITLE
Add LowSelectionPriority and default campaign speed

### DIFF
--- a/game-assets/cncnet.pack/rulesmd.ini
+++ b/game-assets/cncnet.pack/rulesmd.ini
@@ -7590,7 +7590,7 @@ ThreatAvoidanceCoefficient=1
 DamageParticleSystems=SparkSys,SmallGreySSys
 ImmuneToRadiation=yes
 Trainable=no
-LowSelectionPriority=false; Phobos addition - RAZER
+LowSelectionPriority=true; Phobos addition - RAZER
 
 ; harvester
 [CMIN]
@@ -7657,7 +7657,7 @@ StupidHunt=yes ;this guy can't handle a hunt command, so he should just run towa
 Trainable=no
 ResourceGatherer=yes;gs for the AI to handle the slave miner, it has to know if it can make money or not
 Bunkerable=no; Units default to yes, others default to no
-LowSelectionPriority=false; Phobos addition - RAZER
+LowSelectionPriority=true; Phobos addition - RAZER
 
 ; Robot Tank
 [ROBO]
@@ -8456,7 +8456,7 @@ ThreatPosed=0	; This value MUST be 0 for all building addons
 ThreatAvoidanceCoefficient=1
 DamageParticleSystems=SparkSys,SmallGreySSys
 ImmuneToRadiation=yes
-LowSelectionPriority=false; Phobos addition - RAZER
+LowSelectionPriority=true; Phobos addition - RAZER
 
 ; harvester
 [HARV]
@@ -8520,7 +8520,7 @@ EliteAbilities=SELF_HEAL,STRONGER,FIREPOWER,ROF
 ElitePrimary=20mmRapidE
 ResourceGatherer=yes;gs for the AI to handle the slave miner, it has to understand what makes money
 Bunkerable=no; Units default to yes, others default to no
-LowSelectionPriority=false; Phobos addition - RAZER
+LowSelectionPriority=true; Phobos addition - RAZER
 
 [UTNK]
 UIName=Name:UTNK
@@ -9359,7 +9359,7 @@ OmniCrushResistant=yes; so Crusher can crush Crushable, OmniCrusher trumps Crush
 Parasiteable=no
 Unsellable=yes
 BuildTimeMultiplier=0.8
-LowSelectionPriority=false; Phobos addition - RAZER
+LowSelectionPriority=true; Phobos addition - RAZER
 
 ; **************************************************************************
 ; ******************************* Civ Units ********************************
@@ -13556,7 +13556,7 @@ VoiceDeploy=SlaveMinerUnDeployVoice
 Unsellable=yes
 Trainable=yes
 BuildTimeMultiplier=1.15
-LowSelectionPriority=false; Phobos addition - RAZER
+LowSelectionPriority=true; Phobos addition - RAZER
 
 ;Yuri Weapons Factory
 [YAWEAP]

--- a/game-assets/cncnet.pack/rulesmd.ini
+++ b/game-assets/cncnet.pack/rulesmd.ini
@@ -7590,7 +7590,7 @@ ThreatAvoidanceCoefficient=1
 DamageParticleSystems=SparkSys,SmallGreySSys
 ImmuneToRadiation=yes
 Trainable=no
-
+LowSelectionPriority=false; Phobos addition - RAZER
 
 ; harvester
 [CMIN]
@@ -7657,6 +7657,7 @@ StupidHunt=yes ;this guy can't handle a hunt command, so he should just run towa
 Trainable=no
 ResourceGatherer=yes;gs for the AI to handle the slave miner, it has to know if it can make money or not
 Bunkerable=no; Units default to yes, others default to no
+LowSelectionPriority=false; Phobos addition - RAZER
 
 ; Robot Tank
 [ROBO]
@@ -8455,6 +8456,7 @@ ThreatPosed=0	; This value MUST be 0 for all building addons
 ThreatAvoidanceCoefficient=1
 DamageParticleSystems=SparkSys,SmallGreySSys
 ImmuneToRadiation=yes
+LowSelectionPriority=false; Phobos addition - RAZER
 
 ; harvester
 [HARV]
@@ -8518,6 +8520,7 @@ EliteAbilities=SELF_HEAL,STRONGER,FIREPOWER,ROF
 ElitePrimary=20mmRapidE
 ResourceGatherer=yes;gs for the AI to handle the slave miner, it has to understand what makes money
 Bunkerable=no; Units default to yes, others default to no
+LowSelectionPriority=false; Phobos addition - RAZER
 
 [UTNK]
 UIName=Name:UTNK
@@ -9356,6 +9359,7 @@ OmniCrushResistant=yes; so Crusher can crush Crushable, OmniCrusher trumps Crush
 Parasiteable=no
 Unsellable=yes
 BuildTimeMultiplier=0.8
+LowSelectionPriority=false; Phobos addition - RAZER
 
 ; **************************************************************************
 ; ******************************* Civ Units ********************************
@@ -13552,6 +13556,7 @@ VoiceDeploy=SlaveMinerUnDeployVoice
 Unsellable=yes
 Trainable=yes
 BuildTimeMultiplier=1.15
+LowSelectionPriority=false; Phobos addition - RAZER
 
 ;Yuri Weapons Factory
 [YAWEAP]

--- a/game-assets/ra2mode.pack/rulesmd.ini
+++ b/game-assets/ra2mode.pack/rulesmd.ini
@@ -6190,6 +6190,7 @@ ThreatPosed=0	; This value MUST be 0 for all building addons
 ThreatAvoidanceCoefficient=1
 DamageParticleSystems=SparkSys,SmallGreySSys
 ImmuneToRadiation=yes
+LowSelectionPriority=false; Phobos addition - RAZER
 
 ; harvester
 [HARV]
@@ -6248,6 +6249,7 @@ Size=3
 VeteranAbilities=STRONGER,FIREPOWER,SIGHT,FASTER
 EliteAbilities=SELF_HEAL,STRONGER,FIREPOWER,ROF
 ElitePrimary=20mmRapidE
+LowSelectionPriority=false; Phobos addition - RAZER
 
 ; harvester without back
 [CMON]
@@ -6293,6 +6295,7 @@ ThreatAvoidanceCoefficient=1
 DamageParticleSystems=SparkSys,SmallGreySSys
 ImmuneToRadiation=yes
 Trainable=no
+LowSelectionPriority=false; Phobos addition - RAZER
 
 
 ; harvester
@@ -6355,6 +6358,7 @@ ZFudgeBridge=7
 Size=3
 StupidHunt=yes ;this guy can't handle a hunt command, so he should just run towards the player
 Trainable=no
+LowSelectionPriority=false; Phobos addition - RAZER
 
 
 ; Mobile Construction Vehicle

--- a/game-assets/ra2mode.pack/rulesmd.ini
+++ b/game-assets/ra2mode.pack/rulesmd.ini
@@ -6190,7 +6190,7 @@ ThreatPosed=0	; This value MUST be 0 for all building addons
 ThreatAvoidanceCoefficient=1
 DamageParticleSystems=SparkSys,SmallGreySSys
 ImmuneToRadiation=yes
-LowSelectionPriority=false; Phobos addition - RAZER
+LowSelectionPriority=true; Phobos addition - RAZER
 
 ; harvester
 [HARV]
@@ -6249,7 +6249,7 @@ Size=3
 VeteranAbilities=STRONGER,FIREPOWER,SIGHT,FASTER
 EliteAbilities=SELF_HEAL,STRONGER,FIREPOWER,ROF
 ElitePrimary=20mmRapidE
-LowSelectionPriority=false; Phobos addition - RAZER
+LowSelectionPriority=true; Phobos addition - RAZER
 
 ; harvester without back
 [CMON]
@@ -6295,7 +6295,7 @@ ThreatAvoidanceCoefficient=1
 DamageParticleSystems=SparkSys,SmallGreySSys
 ImmuneToRadiation=yes
 Trainable=no
-LowSelectionPriority=false; Phobos addition - RAZER
+LowSelectionPriority=true; Phobos addition - RAZER
 
 
 ; harvester
@@ -6358,7 +6358,7 @@ ZFudgeBridge=7
 Size=3
 StupidHunt=yes ;this guy can't handle a hunt command, so he should just run towards the player
 Trainable=no
-LowSelectionPriority=false; Phobos addition - RAZER
+LowSelectionPriority=true; Phobos addition - RAZER
 
 
 ; Mobile Construction Vehicle

--- a/tools/build-installer/inno/installer.twig
+++ b/tools/build-installer/inno/installer.twig
@@ -78,7 +78,7 @@ Filename: "{tmp}\wic_x86_enu.exe"; Parameters: "/q /norestart"; Flags: runascurr
 Filename: "{tmp}\dotNetFx40_Full_x86_x64.exe"; Parameters: "/norestart /passive /showrmui"; Flags: runascurrentuser; Check: FileExists(ExpandConstant('{tmp}\dotNetFx40_Full_x86_x64.exe')) and ChangeStatusLabel('.NET Framework 4.0')
 Filename: "msiexec.exe"; Parameters: "-i ""{tmp}\xnafx40_redist.msi"" /quiet /norestart"; Flags: runascurrentuser; Check: FileExists(ExpandConstant('{tmp}\xnafx40_redist.msi')) and ChangeStatusLabel('XNA Framework 4.0')
 Filename: "{app}\CnCNetYRLauncher.exe"; WorkingDir: "{app}"; Description: "{cm:LaunchProgram,Yuris Revenge}"; Flags: nowait postinstall runascurrentuser skipifsilent
- 
+
 [INI]
 Filename: "{app}\RA2MD.ini"; Section: "Video"; Key: "UseGraphicsPatch"; String: "Yes"; MinVersion: 6.2
 Filename: "{app}\RA2MD.ini"; Section: "Options"; Key: "Win8Compat"; String: "Yes"; MinVersion: 6.2
@@ -91,6 +91,12 @@ Filename: "{app}\RA2MD.INI"; Section: "Video"; Key: "ScreenHeight"; String: "600
 Filename: "{app}\RA2MD.INI"; Section: "Video"; Key: "ClientResolutionX"; String: "1280"; Flags: createkeyifdoesntexist
 Filename: "{app}\RA2MD.INI"; Section: "Video"; Key: "ClientResolutionY"; String: "720"; Flags: createkeyifdoesntexist
 Filename: "{app}\RA2MD.INI"; Section: "Video"; Key: "BorderlessWindowedClient"; String: "False"; Flags: createkeyifdoesntexist
+
+; set default campaign game speed
+Filename: "{app}\RA2MD.INI"; Section: "Phobos"; Key: "CampaignDefaultGameSpeed"; String: "5"; Flags: createkeyifdoesntexist
+
+; enable selection priority filtering(when mass selecting units via hotkey or box selection, harvesters are ignored)
+Filename: "{app}\RA2MD.INI"; Section: "Phobos"; Key: "PrioritySelectionFiltering"; String: "True"; Flags: createkeyifdoesntexist
 
 Filename: "{app}\RA2.INI"; Section: "Video"; Key: "AllowHiResModes"; String: "Yes"
 Filename: "{app}\RA2.INI"; Section: "Video"; Key: "ScreenWidth"; String: "800"; Flags: createkeyifdoesntexist


### PR DESCRIPTION
Set LowSelectionPriority=True for harvesters in rulesmd.ini files for both ra2 and yr modes to support Phobos selection filtering.

Updated installer script to set default campaign game speed and enable selection priority filtering in RA2MD.INI.

Default campaign speed is now set to 60fps.



Please note this is my first time trying to set/write values to `ra2md.ini`. Verification or corrections would be appreciated