### PR TITLE
Reimplement GetFolderSize() in response to the submodule update

### DIFF
--- a/tools/mix-packer/ExFS.ts
+++ b/tools/mix-packer/ExFS.ts
@@ -1,9 +1,6 @@
 import * as fs from "fs-extra";
 import * as path from "path";
 import * as glob from "glob";
-const fastFolderSizeSync = require("fast-folder-size/sync") as (
-    target: string
-) => number;
 
 function toPosixPath(pathStr: string) {
     return pathStr.replace(/\\/g, "/");
@@ -52,7 +49,24 @@ export default class ExFS {
     }
 
     static GetFolderSize(folderPath: string) {
-        return fastFolderSizeSync(folderPath) || 0;
+        if (!fs.existsSync(folderPath)) return 0;
+
+        try {
+            const globPattern = toPosixPath(path.join(folderPath, "**", "*"));
+            const files = glob.sync(globPattern, { nodir: true, absolute: true });
+            let total = 0;
+            for (const f of files) {
+                try {
+                    const st = fs.statSync(f);
+                    total += st.size || 0;
+                } catch {
+                    // ignore files that disappear / are inaccessible
+                }
+            }
+            return total;
+        } catch {
+            return 0;
+        }
     }
 
     static GetFile(filePath: string) {

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -15,7 +15,6 @@
         "@types/fs-extra": "^11.0.4",
         "@types/node": "^18.14.0",
         "commander": "^10.0.0",
-        "fast-folder-size": "^2.2.0",
         "fs-extra": "^11.1.1",
         "glob": "^10.3.3",
         "irc": "^0.5.2",
@@ -809,19 +808,6 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "dependencies": {
         "once": "^1.4.0"
-      }
-    },
-    "node_modules/fast-folder-size": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/fast-folder-size/-/fast-folder-size-2.2.0.tgz",
-      "integrity": "sha512-7VsTlT/ELl5OQ4fnckM3idvaUkdJxf6VaYn0sC43GWoRmKqvbGfpoyC4BC/imTd9CEZtlfNsEf8/ZqdfoU4Nwg==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "decompress": "^4.2.1",
-        "https-proxy-agent": "^7.0.0"
-      },
-      "bin": {
-        "fast-folder-size": "cli.js"
       }
     },
     "node_modules/fd-slicer": {
@@ -2459,15 +2445,6 @@
       "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
       "requires": {
         "once": "^1.4.0"
-      }
-    },
-    "fast-folder-size": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/fast-folder-size/-/fast-folder-size-2.2.0.tgz",
-      "integrity": "sha512-7VsTlT/ELl5OQ4fnckM3idvaUkdJxf6VaYn0sC43GWoRmKqvbGfpoyC4BC/imTd9CEZtlfNsEf8/ZqdfoU4Nwg==",
-      "requires": {
-        "decompress": "^4.2.1",
-        "https-proxy-agent": "^7.0.0"
       }
     },
     "fd-slicer": {

--- a/tools/package.json
+++ b/tools/package.json
@@ -26,7 +26,6 @@
     "@types/fs-extra": "^11.0.4",
     "@types/node": "^18.14.0",
     "commander": "^10.0.0",
-    "fast-folder-size": "^2.2.0",
     "fs-extra": "^11.1.1",
     "glob": "^10.3.3",
     "irc": "^0.5.2",


### PR DESCRIPTION
Fix the CI error below:

```
Run npm run mix-packer

> cncnet-yr-client-package-tools@1.0.0 mix-packer
> ts-node mix-packer

..\game-assets\cncnet.pack\presents.mix
The system cannot find the path specified.
Error: Command failed: "D:\a\cncnet-yr-client-package\cncnet-yr-client-package\tools\node_modules\fast-folder-size\bin\du64.exe" -nobanner -accepteula -q -c .
The system cannot find the path specified.

    at genericNodeError (node:internal/errors:983:15)
    at wrappedFn (node:internal/errors:537:14)
    at checkExecSyncError (node:child_process:916:11)
    at execSync (node:child_process:988:15)
    at fastFolderSize (D:\a\cncnet-yr-client-package\cncnet-yr-client-package\tools\node_modules\fast-folder-size\sync.js:8:18)
    at Function.GetFolderSize (D:\a\cncnet-yr-client-package\cncnet-yr-client-package\tools\mix-packer\ExFS.ts:55:16)
    at new MIXFile (D:\a\cncnet-yr-client-package\cncnet-yr-client-package\tools\mix-packer\MIXFile.ts:29:18)
    at Object.<anonymous> (D:\a\cncnet-yr-client-package\cncnet-yr-client-package\tools\mix-packer\index.ts:24:5)
    at Module._compile (node:internal/modules/cjs/loader:1706:14)
    at Module.m._compile (D:\a\cncnet-yr-client-package\cncnet-yr-client-package\tools\node_modules\ts-node\src\index.ts:1618:23)
```