### PR TITLE
Handle read-only files in the installer

### DIFF
--- a/tools/build-installer/inno/installer.twig
+++ b/tools/build-installer/inno/installer.twig
@@ -63,7 +63,7 @@ Type: filesandordirs; Name: "{app}\{{ item }}"
 
 [Files]
 Source: {{ netCoreCheckPath }}\*; Flags: dontcopy noencryption
-Source: *; DestDir: "{app}"; Excludes: "{{ excludedInstallerFiles }}"; Flags: recursesubdirs ignoreversion
+Source: *; DestDir: "{app}"; Excludes: "{{ excludedInstallerFiles }}"; Flags: recursesubdirs ignoreversion OverWriteReadOnly
 ; explicitly list "version" file so that an error is thrown if it does not exist
 Source: version; DestDir: "{app}";
 ; explicitly list "gamemd-spawn.exe" file so that an error is thrown if it does not exist
@@ -299,5 +299,6 @@ begin
   if RunsOnWine() then exit;
 
 end;
+
 
 

--- a/tools/build-installer/inno/installer.twig
+++ b/tools/build-installer/inno/installer.twig
@@ -299,6 +299,3 @@ begin
   if RunsOnWine() then exit;
 
 end;
-
-
-

--- a/tools/build-installer/inno/installer.twig
+++ b/tools/build-installer/inno/installer.twig
@@ -63,7 +63,7 @@ Type: filesandordirs; Name: "{app}\{{ item }}"
 
 [Files]
 Source: {{ netCoreCheckPath }}\*; Flags: dontcopy noencryption
-Source: *; DestDir: "{app}"; Excludes: "{{ excludedInstallerFiles }}"; Flags: recursesubdirs ignoreversion OverWriteReadOnly
+Source: *; DestDir: "{app}"; Excludes: "{{ excludedInstallerFiles }}"; Flags: recursesubdirs ignoreversion overwritereadonly
 ; explicitly list "version" file so that an error is thrown if it does not exist
 Source: version; DestDir: "{app}";
 ; explicitly list "gamemd-spawn.exe" file so that an error is thrown if it does not exist


### PR DESCRIPTION
Avoids the following screenshot introduced since client v2.11.2. Tested on my Windows 11 machine
<img width="980" height="744" alt="图片" src="https://github.com/user-attachments/assets/2b9710ab-cf4e-4f71-bc53-0e07ca81770e" />
