### PR TITLE
Remove U+FFFD characters in the installer license

### DIFF
--- a/tools/build-installer/inno/Resources/License-YurisRevenge.txt
+++ b/tools/build-installer/inno/Resources/License-YurisRevenge.txt
@@ -1,6 +1,6 @@
 This is an unofficial fan made installer, CnCNet is not affiliated with Electronic Arts in any way and trademarks belong to their respective owners.
 
-Command & Conquer and Command & Conquer: Yuri's Revenge are registered trademarks of Electronic Arts, all rights reserved.
+Command & Conquer™ and Command & Conquer: Yuri's Revenge™ are registered trademarks of Electronic Arts, all rights reserved.
 http://www.commandandconquer.com
 
 To be able to continue you must agree to the following:

--- a/tools/build-installer/inno/Resources/License-YurisRevenge.txt
+++ b/tools/build-installer/inno/Resources/License-YurisRevenge.txt
@@ -1,6 +1,6 @@
 This is an unofficial fan made installer, CnCNet is not affiliated with Electronic Arts in any way and trademarks belong to their respective owners.
 
-Command & Conquer� and Command & Conquer: Yuri's Revenge� are registered trademarks of Electronic Arts, all rights reserved.
+Command & Conquer and Command & Conquer: Yuri's Revenge are registered trademarks of Electronic Arts, all rights reserved.
 http://www.commandandconquer.com
 
 To be able to continue you must agree to the following:


### PR DESCRIPTION
Avoids:

<img width="1049" height="773" alt="图片" src="https://github.com/user-attachments/assets/91b77589-d5cd-4b62-8bcd-388662d1c87c" />

Better merge this PR after #694, since I have noticed this change log

> 6.3: Support for UTF-8 encoded files without a BOM.

