### PR TITLE
Reimplement GetFolderSize() in mix-packer for the cases when the usual one fails; add style config to mix-packer

### DIFF
--- a/tools/mix-packer/.prettierrc.json
+++ b/tools/mix-packer/.prettierrc.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "https://json.schemastore.org/prettierrc",
+    "arrowParens": "always",
+    "bracketSpacing": true,
+    "bracketSameLine": false,
+    "printWidth": 120,
+    "semi": true,
+    "singleQuote": false,
+    "tabWidth": 4,
+    "trailingComma": "all",
+    "useTabs": false
+}

--- a/tools/mix-packer/ExFS.ts
+++ b/tools/mix-packer/ExFS.ts
@@ -1,9 +1,7 @@
 import * as fs from "fs-extra";
 import * as path from "path";
 import * as glob from "glob";
-const fastFolderSizeSync = require("fast-folder-size/sync") as (
-    target: string
-) => number;
+const fastFolderSizeSync = require("fast-folder-size/sync") as (target: string) => number;
 
 function toPosixPath(pathStr: string) {
     return pathStr.replace(/\\/g, "/");
@@ -52,7 +50,34 @@ export default class ExFS {
     }
 
     static GetFolderSize(folderPath: string) {
-        return fastFolderSizeSync(folderPath) || 0;
+        if (!fs.existsSync(folderPath)) {
+            return 0;
+        }
+
+        try {
+            // Try the quick method
+            return fastFolderSizeSync(folderPath) || 0;
+        } catch {
+            try {
+                const globPattern = toPosixPath(path.join(folderPath, "**", "*"));
+                const filesList = glob.sync(globPattern, { nodir: true, absolute: true });
+
+                let totalSize = 0;
+                for (const currentFile of filesList) {
+                    try {
+                        const st = fs.statSync(currentFile);
+                        totalSize += st.size || 0;
+                    } catch {
+                        // ignore files that disappear / are inaccessible
+                        continue;
+                    }
+                }
+
+                return totalSize;
+            } catch {
+                return 0;
+            }
+        }
     }
 
     static GetFile(filePath: string) {

--- a/tools/mix-packer/MIXFile.ts
+++ b/tools/mix-packer/MIXFile.ts
@@ -25,9 +25,7 @@ export default class MIXFile {
 
         const filesArray = ExFS.GetFileArray(this.folderPath);
 
-        this.body = new ExBuffer(
-            ExFS.GetFolderSize(this.folderPath) + filesArray.length
-        );
+        this.body = new ExBuffer(ExFS.GetFolderSize(this.folderPath) + filesArray.length);
 
         for (let i = 0; i < filesArray.length; i++) {
             this.addFile(filesArray[i]);
@@ -40,11 +38,7 @@ export default class MIXFile {
         const id = MIXFile.getID(fileName);
 
         if (this.includedFilesID.has(id)) {
-            console.log(
-                `fileID =${id.toString(
-                    16
-                )}, filePath =${filePath} Has in ${path}`
-            );
+            console.log(`fileID =${id.toString(16)}, filePath =${filePath} Has in ${path}`);
             throw new Error();
         }
 
@@ -60,11 +54,9 @@ export default class MIXFile {
     addLocalMixDatabase() {
         const fileName = "local mix database.dat";
 
-        const fileList = Array.from(this.includedFilesID.values()).map(
-            (el) => el.fileName
-        );
-        fileList.push(fileName)
-        fileList.sort()
+        const fileList = Array.from(this.includedFilesID.values()).map((el) => el.fileName);
+        fileList.push(fileName);
+        fileList.sort();
 
         const body = fileList.join("\x00");
         const size = 0x34 + body.length + 1;


### PR DESCRIPTION
Same as #696, but leaves fastFolderSizeSync as default, and the SadPencil implementation is left as a fallback