### PR TITLE
Lift 260-char MAX_PATH limitation in installer

### DIFF
--- a/tools/build-installer/inno/installer.twig
+++ b/tools/build-installer/inno/installer.twig
@@ -103,6 +103,8 @@ Type: filesandordirs; Name: "{app}\Resources"
 Type: filesandordirs; Name: "{app}\Client"
 
 [Registry]
+Root: HKLM; Subkey: SYSTEM\CurrentControlSet\Control\FileSystem; ValueType: dword; ValueName: LongPathsEnabled; ValueData: 1; Flags: noerror
+
 Root: HKLM; Subkey: Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers; ValueType: String; ValueName: {app}\gamemd-spawn.exe; ValueData: "HIGHDPIAWARE"
 Root: HKCU; Subkey: Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers; ValueType: String; ValueName: {app}\gamemd-spawn.exe; ValueData: "HIGHDPIAWARE"
 

--- a/tools/build-installer/inno/installer.twig
+++ b/tools/build-installer/inno/installer.twig
@@ -103,7 +103,7 @@ Type: filesandordirs; Name: "{app}\Resources"
 Type: filesandordirs; Name: "{app}\Client"
 
 [Registry]
-Root: HKLM; Subkey: SYSTEM\CurrentControlSet\Control\FileSystem; ValueType: dword; ValueName: LongPathsEnabled; ValueData: 1; Flags: noerror
+Root: HKLM; Subkey: SYSTEM\CurrentControlSet\Control\FileSystem; ValueType: dword; ValueName: LongPathsEnabled; ValueData: 1; Flags: noerror; MinVersion: 10.0.14393
 
 Root: HKLM; Subkey: Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers; ValueType: String; ValueName: {app}\gamemd-spawn.exe; ValueData: "HIGHDPIAWARE"
 Root: HKCU; Subkey: Software\Microsoft\Windows NT\CurrentVersion\AppCompatFlags\Layers; ValueType: String; ValueName: {app}\gamemd-spawn.exe; ValueData: "HIGHDPIAWARE"


### PR DESCRIPTION
This PR globally enable MAX_PATH lift in Windows, same as what qBittorrent/Python etc does.

Example of a long path:
<img width="1574" height="610" alt="" src="https://github.com/user-attachments/assets/b8146c31-c2bb-4d6b-94c5-95063f3d33fc" />


To make it really take effects, we also need to upgrade the launcher and the client
- https://github.com/CnCNet/xna-cncnet-client/pull/870/
- https://github.com/CnCNet/dta-mg-client-launcher/pull/19/

Ref: https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation

> Starting in Windows 10, version 1607, MAX_PATH limitations have been removed from many common Win32 file and directory functions. **However, your app must opt-in to the new behavior.**

> To enable the new long path behavior per application, **two conditions must be met**. A registry value must be set, and the application manifest must include the longPathAware element.

> Understand that enabling this registry setting **will only affect applications that have been modified to take advantage of the new feature**. Developers must declare their apps to be long path aware, as outlined in the application manifest settings [below](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=registry#application-manifest-updates-to-declare-long-path-capability). This isn't a change that will affect all applications.