### PR TITLE
Disable NotifyOnUserListChange option in installer

### DIFF
--- a/tools/build-installer/inno/installer.twig
+++ b/tools/build-installer/inno/installer.twig
@@ -78,6 +78,7 @@ Filename: "{app}\CnCNetYRLauncher.exe"; WorkingDir: "{app}"; Description: "{cm:L
 [INI]
 Filename: "{app}\RA2MD.ini"; Section: "Video"; Key: "UseGraphicsPatch"; String: "Yes"; MinVersion: 6.2
 Filename: "{app}\RA2MD.ini"; Section: "Options"; Key: "Win8Compat"; String: "Yes"; MinVersion: 6.2
+Filename: "{app}\RA2MD.ini"; Section: "MultiPlayer"; Key: "NotifyOnUserListChange"; String: "False"
 
 Filename: "{app}\RA2MD.INI"; Section: "Video"; Key: "AllowHiResModes"; String: "Yes"
 Filename: "{app}\RA2MD.INI"; Section: "Video"; Key: "ScreenWidth"; String: "800"; Flags: createkeyifdoesntexist


### PR DESCRIPTION
For some users that already having `NotifyOnUserListChange=True` in their `RA2MD.ini`, at least we can make sure a re-installation resets this value