### PR TITLE
Add Power Delta, Harvester Counter and organize OptionsWindow.ini

### DIFF
--- a/game-assets/cncnet.pack/uimd.ini
+++ b/game-assets/cncnet.pack/uimd.ini
@@ -10,6 +10,12 @@ ButtonList=Team01,Team02,TypeSelect,Deploy,Guard,PlanningMode,Beacon
 
 [Sidebar]
 CenterPauseMenuBackground=yes
+HarvesterCounter.Show=yes
+HarvesterCounter.ConditionYellow=99%
+HarvesterCounter.ConditionRed=50%
+PowerDelta.Show=yes
+PowerDelta.ConditionYellow=75%
+PowerDelta.ConditionRed=100%
 
 [ToolTips]
 ExtendedToolTips=yes

--- a/game-assets/ra2mode.pack/uimd.ini
+++ b/game-assets/ra2mode.pack/uimd.ini
@@ -10,6 +10,12 @@ ButtonList=Team01,Team02,TypeSelect,Deploy,Guard,PlanningMode,Beacon
 
 [Sidebar]
 CenterPauseMenuBackground=yes
+HarvesterCounter.Show=yes
+HarvesterCounter.ConditionYellow=99%
+HarvesterCounter.ConditionRed=50%
+PowerDelta.Show=yes
+PowerDelta.ConditionYellow=75%
+PowerDelta.ConditionRed=100%
 
 [ToolTips]
 ExtendedToolTips=yes

--- a/package/Resources/OptionsWindow.ini
+++ b/package/Resources/OptionsWindow.ini
@@ -2,6 +2,9 @@
 DrawMode=Stretched
 BackgroundTexture=ModalBG.png
 
+; ==========================
+; Audio Menu Options
+; ==========================
 [AudioOptionsPanelExtraControls]
 0=chkTaunts:SettingCheckBox
 
@@ -12,6 +15,9 @@ DefaultValue=true
 SettingSection=Options
 SettingKey=AllowTaunts
 
+; ==========================
+; Game Menu Options
+; ==========================
 [GameOptionsPanelExtraControls]
 0=chkAllowChat:SettingCheckBox
 1=chkBuildingPlacement:SettingCheckBox
@@ -19,25 +25,42 @@ SettingKey=AllowTaunts
 3=chkSkipScoreScreen:SettingCheckBox
 4=chkSpeedControl:SettingCheckBox
 5=chkPrioritySelection:SettingCheckBox
+6=chkHarvesterCounter:SettingCheckBox
+7=chkPowerDelta:SettingCheckBox
 
 [lblPlayerName]
-Location=12,188
+Location=12,212
 
 [tbPlayerName]
-Location=113,186
+Location=113,210
 
 [btnConfigureHotkeys]
-Location=12,266
+Location=12,290
 
 [lblNotice]
-Location=12,216
+Location=12,240
 
+; Left Side Toggles
 [chkScrollCoasting]
+Location=12,54
+ToolTip=Enable smooth scrolling.
 DefaultValue=true
 SettingSection=Options
 SettingKey=DisableEdgeScrolling
 EnabledSettingValue=false
 DisabledSettingValue=true
+
+[chkTargetLines]
+Location=12,78
+ToolTip=Show lines between selected units and targets.@Green lines indicate movement, red lines attack.
+
+[chkShowHiddenObjects]
+Location=242,126
+ToolTip=Display a visual indicator when an object is visually hidden behind something.
+
+[chkTooltips]
+Location=12,126
+ToolTip=Enable in-game tooltips.
 
 [chkAllowChat]
 Location=12,150
@@ -47,32 +70,41 @@ DefaultValue=true
 SettingSection=Options
 SettingKey=AllowChat
 
-[chkBuildingPlacement]
-Location=242,54
-Text=Show Building Placement Preview
-ToolTip=When enabled, shows a preview image of the building when placing it
-DefaultValue=false
-SettingSection=Phobos
-SettingKey=ShowPlacementPreview
-
 [chkQuickExit]
-Location=242,78
+Location=12,174
 Text=Quick Exit
 ToolTip=When enabled, you can exit the game by pressing Alt+F4
 DefaultValue=true
 SettingSection=Options
 SettingKey=QuickExit
 
-[chkSkipScoreScreen]
+; Right Side Toggles
+[chkHarvesterCounter]
+Location=242,150
+Text=Show Harvester Counter
+ToolTip=If enabled, an additional counter near your credits indicator will show active and total harvester counts.
+DefaultValue=false
+SettingSection=Phobos
+SettingKey=ShowHarvesterCounter
+
+[chkPowerDelta]
 Location=242,102
+Text=Show Power Delta
+ToolTip=If enabled, an additional counter near your credits indicator will show power delta (total - consumption).
+DefaultValue=false
+SettingSection=Phobos
+SettingKey=ShowPowerDelta
+
+[chkSkipScoreScreen]
+Location=12,102
 Text=Skip Score Screen
-ToolTip=
+ToolTip=Return to main menu immediately after a game is finished.
 DefaultValue=false
 SettingSection=Options
 SettingKey=SkipScoreScreen
 
 [chkSpeedControl]
-Location=242,126
+Location=242,78
 Text=Control Campaign Speed
 ToolTip=When enabled, you can change the game speed while playing the campaign@This option is not normally available for campaign mode
 DefaultValue=false
@@ -80,13 +112,24 @@ SettingSection=Options
 SettingKey=SpeedControl
 
 [chkPrioritySelection]
-Location=242,150
+Location=242,54
 Text=Mass Selection Filtering
 ToolTip=If enabled, non-combat units are not selected if mass-selecting together with combat units.
 DefaultValue=false
 SettingSection=Phobos
 SettingKey=PrioritySelectionFiltering
 
+[chkBuildingPlacement]
+Location=242,174
+Text=Show Building Placement Preview
+ToolTip=When enabled, shows a preview image of the building when placing it
+DefaultValue=false
+SettingSection=Phobos
+SettingKey=ShowPlacementPreview
+
+; ==========================
+; Updater Menu Items
+; ==========================
 [UpdaterOptionsPanelExtraControls]
 0=lblUpdateChannel:XNALabel
 1=ddUpdateChannel:FileSettingDropDown

--- a/package/Resources/OptionsWindow.ini
+++ b/package/Resources/OptionsWindow.ini
@@ -54,9 +54,13 @@ DisabledSettingValue=true
 Location=12,78
 ToolTip=Show lines between selected units and targets.@Green lines indicate movement, red lines attack.
 
-[chkShowHiddenObjects]
-Location=242,126
-ToolTip=Display a visual indicator when an object is visually hidden behind something.
+[chkQuickExit]
+Location=12,102
+Text=Quick Exit
+ToolTip=When enabled, you can exit the game by pressing Alt+F4
+DefaultValue=true
+SettingSection=Options
+SettingKey=QuickExit
 
 [chkTooltips]
 Location=12,126
@@ -70,38 +74,22 @@ DefaultValue=true
 SettingSection=Options
 SettingKey=AllowChat
 
-[chkQuickExit]
-Location=12,174
-Text=Quick Exit
-ToolTip=When enabled, you can exit the game by pressing Alt+F4
-DefaultValue=true
-SettingSection=Options
-SettingKey=QuickExit
-
-; Right Side Toggles
-[chkHarvesterCounter]
-Location=242,150
-Text=Show Harvester Counter
-ToolTip=If enabled, an additional counter near your credits indicator will show active and total harvester counts.
-DefaultValue=false
-SettingSection=Phobos
-SettingKey=ShowHarvesterCounter
-
-[chkPowerDelta]
-Location=242,102
-Text=Show Power Delta
-ToolTip=If enabled, an additional counter near your credits indicator will show power delta (total - consumption).
-DefaultValue=false
-SettingSection=Phobos
-SettingKey=ShowPowerDelta
-
 [chkSkipScoreScreen]
-Location=12,102
+Location=12,174
 Text=Skip Score Screen
 ToolTip=Return to main menu immediately after a game is finished.
 DefaultValue=false
 SettingSection=Options
 SettingKey=SkipScoreScreen
+
+; Right Side Toggles
+[chkPrioritySelection]
+Location=242,54
+Text=Mass Selection Filtering
+ToolTip=If enabled, non-combat units are not selected if mass-selecting together with combat units.
+DefaultValue=false
+SettingSection=Phobos
+SettingKey=PrioritySelectionFiltering
 
 [chkSpeedControl]
 Location=242,78
@@ -111,13 +99,25 @@ DefaultValue=false
 SettingSection=Options
 SettingKey=SpeedControl
 
-[chkPrioritySelection]
-Location=242,54
-Text=Mass Selection Filtering
-ToolTip=If enabled, non-combat units are not selected if mass-selecting together with combat units.
+[chkPowerDelta]
+Location=242,102
+Text=Show Power Delta
+ToolTip=If enabled, an additional counter near your credits indicator will show power delta (total - consumption).
 DefaultValue=false
 SettingSection=Phobos
-SettingKey=PrioritySelectionFiltering
+SettingKey=ShowPowerDelta
+
+[chkShowHiddenObjects]
+Location=242,126
+ToolTip=Display a visual indicator when an object is visually hidden behind something.
+
+[chkHarvesterCounter]
+Location=242,150
+Text=Show Harvester Counter
+ToolTip=If enabled, an additional counter near your credits indicator will show active and total harvester counts.
+DefaultValue=false
+SettingSection=Phobos
+SettingKey=ShowHarvesterCounter
 
 [chkBuildingPlacement]
 Location=242,174


### PR DESCRIPTION
This pull request introduces new sidebar features and corresponding options for displaying a Harvester Counter and Power Delta in the game UI, as well as updates to the options menu to support these features and improve usability. The changes are primarily focused on making resource and power management more visible to players and giving them more control over UI elements.

**Sidebar display enhancements:**

* Added `HarvesterCounter` and `PowerDelta` display options to the sidebar in both `uimd.ini` files, including thresholds for yellow and red warnings. [[1]](diffhunk://#diff-5f968af425dafc77a17932665b7c0de4d2065b50ba0d6af8a7f533147317d2d6R13-R18) [[2]](diffhunk://#diff-a56e123d432606cc40abbd232868d36ad8e06883f6d9372d64e5e587beed218eR13-R18)

**Options menu improvements:**

* Added new checkboxes for toggling the Harvester Counter and Power Delta displays in the options window (`OptionsWindow.ini`), allowing users to enable or disable these features from the game menu.
* Improved organization and tooltips for existing and new options in the options window, including better grouping, clearer descriptions, and UI layout adjustments for controls like chat, tooltips, and selection filtering.
* Added section headers for audio, game, and updater menu options in `OptionsWindow.ini` for better readability and maintainability. [[1]](diffhunk://#diff-5ab8b261566713aa5b57e523fd5ddb5962757f05382d459e1ac48e295ee84a40R5-R7) [[2]](diffhunk://#diff-5ab8b261566713aa5b57e523fd5ddb5962757f05382d459e1ac48e295ee84a40R18-R132)

### Options window:
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/afb76fd9-2df8-4957-9beb-b77e29575994" />

### Ingame Appearance:
<img width="1280" height="768" alt="image" src="https://github.com/user-attachments/assets/d3b9164c-421e-4fa9-89f0-4e6641133e51" />
