### PR TITLE
Add game.fnt in parallel with cncnet.fnt file to the translation file list

### DIFF
--- a/package/Resources/ClientDefinitions.ini
+++ b/package/Resources/ClientDefinitions.ini
@@ -65,7 +65,8 @@ Youtube=https://youtube.com/user/cncnetofficial
 Twitch=https://www.twitch.tv/cncnetofficial
 
 [Translations]
-GameFile_GameFnt=game.fnt,cncnet.fnt
+GameFile_CnCNetFnt=game.fnt,cncnet.fnt
+GameFile_GameFnt=game.fnt,game.fnt
 GameFile_Ra2Csf=ra2.csf,ra2.csf
 GameFile_Ra2MdCsf=ra2md.csf,ra2md.csf
 GameFile_CameoMix=cameo.mix,cameo.mix


### PR DESCRIPTION
This is because CnCNet YR is installed on an existing RA2 installation

without game.fnt file, it causes inconsistent state to the original RA2 installation

in the following screenshot, the character that looks like `口` indicates a missing character in the (original) game font

<img width="360" height="51" alt="图片" src="https://github.com/user-attachments/assets/eb272c3f-f3e3-456b-8a1d-4e8e3447753a" />
