### PR TITLE
Fix Waterfall Sound

### DIFF
--- a/game-assets/cncnet.pack/soundmd.ini
+++ b/game-assets/cncnet.pack/soundmd.ini
@@ -2727,6 +2727,8 @@ Control= loop random all attack
 Sounds=awatloa awatlob awatloc
 Control= random all loop
 Priority= low
+Type=local
+Range=16
 Limit=2
 Volume=15
 

--- a/game-assets/ra2mode.pack/SOUNDS/sound.ini
+++ b/game-assets/ra2mode.pack/SOUNDS/sound.ini
@@ -2977,6 +2977,8 @@ Control= loop random all attack
 Sounds=awatloa awatlob awatloc
 Control= random all loop
 Priority= low
+Type=local
+Range=16
 Limit=2
 Volume=15
 


### PR DESCRIPTION
The sound type for the waterfall is simply undefined. This results in its radius being huge and audible when the waterfall is off-screen. This noise is annoying. In my maps, I kill half the waterfall to get rid of this noise. With these fixes, the sound returns to normal, as it should be. At the edge of the screen it's quieter, in the center normal.

Partially fixes #307
