### PR TITLE
Add MultiEngineer settings to rulesmd.ini files

### DIFF
--- a/game-assets/cncnet.pack/rulesmd.ini
+++ b/game-assets/cncnet.pack/rulesmd.ini
@@ -567,6 +567,9 @@ DropZoneAnim=BEACON     ; animation to use for the drop zone flair
 EMPulseSparkles=EMP_FX01	; Anim to play over units disabled by an EM Pulse.
 
 UnitsUnsellable=yes ; belonit - additions needed for Ares
+EngineerAlwaysCaptureTech=no ; RAZER - additions needed for Ares (MultiEngineer)
+EngineerDamage=34% ; RAZER - additions needed for Ares (MultiEngineer)
+EngineerCaptureLevel=35% ; RAZER - additions needed for Ares (MultiEngineer)
 
 [GlobalControls]
 DebugKeysEnabled=no

--- a/game-assets/cncnet.pack/rulesmd.ini
+++ b/game-assets/cncnet.pack/rulesmd.ini
@@ -567,7 +567,7 @@ DropZoneAnim=BEACON     ; animation to use for the drop zone flair
 EMPulseSparkles=EMP_FX01	; Anim to play over units disabled by an EM Pulse.
 
 UnitsUnsellable=yes ; belonit - additions needed for Ares
-EngineerAlwaysCaptureTech=no ; RAZER - additions needed for Ares (MultiEngineer)
+EngineerAlwaysCaptureTech=yes ; RAZER - additions needed for Ares (MultiEngineer)
 EngineerDamage=34% ; RAZER - additions needed for Ares (MultiEngineer)
 EngineerCaptureLevel=35% ; RAZER - additions needed for Ares (MultiEngineer)
 

--- a/game-assets/ra2mode.pack/rulesmd.ini
+++ b/game-assets/ra2mode.pack/rulesmd.ini
@@ -49,7 +49,7 @@ WeatherConBolts=WCLBOLT1,WCLBOLT2,WCLBOLT3
 WeatherConClouds=WCCLOUD1,WCCLOUD2,WCCLOUD3
 
 UnitsUnsellable=yes ; belonit - additions needed for Ares
-EngineerAlwaysCaptureTech=no ; RAZER - additions needed for Ares (MultiEngineer)
+EngineerAlwaysCaptureTech=yes ; RAZER - additions needed for Ares (MultiEngineer)
 EngineerDamage=34% ; RAZER - additions needed for Ares (MultiEngineer)
 EngineerCaptureLevel=35% ; RAZER - additions needed for Ares (MultiEngineer)
 

--- a/game-assets/ra2mode.pack/rulesmd.ini
+++ b/game-assets/ra2mode.pack/rulesmd.ini
@@ -49,6 +49,9 @@ WeatherConBolts=WCLBOLT1,WCLBOLT2,WCLBOLT3
 WeatherConClouds=WCCLOUD1,WCCLOUD2,WCCLOUD3
 
 UnitsUnsellable=yes ; belonit - additions needed for Ares
+EngineerAlwaysCaptureTech=no ; RAZER - additions needed for Ares (MultiEngineer)
+EngineerDamage=34% ; RAZER - additions needed for Ares (MultiEngineer)
+EngineerCaptureLevel=35% ; RAZER - additions needed for Ares (MultiEngineer)
 
 UIName=Name:General
 Name=Red Alert 2 -- Official Rules of Engagement


### PR DESCRIPTION
Introduced EngineerAlwaysCaptureTech, EngineerDamage, and EngineerCaptureLevel parameters to both cncnet.pack and ra2mode.pack rulesmd.ini files for Ares MultiEngineer support.