### PR TITLE
Update maps updater script

### DIFF
--- a/tools/mpmaps-updater/class/ini-file.class.ts
+++ b/tools/mpmaps-updater/class/ini-file.class.ts
@@ -42,10 +42,17 @@ export class IniFile {
         const content = await util.promisify(readFile)(filePath, {
             encoding: 'utf-8'
         });
-        const iniObject = parseIni(content, {
+        const sanitized = IniFile.sanitizeIniContent(content);
+        const iniObject = parseIni(sanitized, {
             autoTyping: false
         });
         return new IniFile(filePath, iniObject);
+    }
+    public static sanitizeIniContent(content: string): string {
+        // Remove lines that start with NOSTR: (optionally preceded by whitespace)
+        // Example offending line: "NOSTR:Yuri Defense Platform"
+        const withoutBareNostr = content.replace(/^\s*NOSTR:.*$/gmi, '');
+        return withoutBareNostr;
     }
 
     /**


### PR DESCRIPTION
This pull request improves the robustness of the `IniFile` class by adding a sanitization step before parsing INI file content. The main change is the introduction of a method to remove problematic lines that start with `NOSTR:` from the INI file content, which helps prevent parsing errors.

**INI file content sanitization:**

* Added a static method `sanitizeIniContent` to the `IniFile` class that removes lines starting with `NOSTR:` (optionally preceded by whitespace) from the INI file content before parsing. (`tools/mpmaps-updater/class/ini-file.class.ts`)
* Updated the `fromFile` method to use the sanitized content when parsing the INI file. (`tools/mpmaps-updater/class/ini-file.class.ts`)

<img width="1506" height="530" alt="image" src="https://github.com/user-attachments/assets/c5873f8e-9c87-4717-a3b0-51d4aba13ba9" />
