### PR TITLE
Refactor Multi Engineer option to use custom INI file

### DIFF
--- a/game-assets/cncnet.pack/rulesmd.ini
+++ b/game-assets/cncnet.pack/rulesmd.ini
@@ -567,9 +567,6 @@ DropZoneAnim=BEACON     ; animation to use for the drop zone flair
 EMPulseSparkles=EMP_FX01	; Anim to play over units disabled by an EM Pulse.
 
 UnitsUnsellable=yes ; belonit - additions needed for Ares
-EngineerAlwaysCaptureTech=yes ; RAZER - additions needed for Ares (MultiEngineer)
-EngineerDamage=34% ; RAZER - additions needed for Ares (MultiEngineer)
-EngineerCaptureLevel=35% ; RAZER - additions needed for Ares (MultiEngineer)
 
 [GlobalControls]
 DebugKeysEnabled=no

--- a/game-assets/ra2mode.pack/rulesmd.ini
+++ b/game-assets/ra2mode.pack/rulesmd.ini
@@ -49,9 +49,6 @@ WeatherConBolts=WCLBOLT1,WCLBOLT2,WCLBOLT3
 WeatherConClouds=WCCLOUD1,WCCLOUD2,WCCLOUD3
 
 UnitsUnsellable=yes ; belonit - additions needed for Ares
-EngineerAlwaysCaptureTech=yes ; RAZER - additions needed for Ares (MultiEngineer)
-EngineerDamage=34% ; RAZER - additions needed for Ares (MultiEngineer)
-EngineerCaptureLevel=35% ; RAZER - additions needed for Ares (MultiEngineer)
 
 UIName=Name:General
 Name=Red Alert 2 -- Official Rules of Engagement

--- a/package/INI/Game Options/Multi Engineer.ini
+++ b/package/INI/Game Options/Multi Engineer.ini
@@ -1,0 +1,4 @@
+[General]
+EngineerAlwaysCaptureTech=yes
+EngineerDamage=34%
+EngineerCaptureLevel=35%

--- a/package/Resources/GameLobbyBase.ini
+++ b/package/Resources/GameLobbyBase.ini
@@ -314,6 +314,7 @@ $Y=getBottom(chkRedeplMCV) + GAME_OPTION_ROW_SPACING
 
 [chkMultiEng]
 SpawnIniOption=MultiEngineer
+CustomIniPath=INI\Game Options\Multi Engineer.ini
 Checked=False
 ToolTip=Capturing a structure requires three Engineers instead of one.
 Text=Multi Engineer


### PR DESCRIPTION
Moved Multi Engineer settings from rulesmd.ini files to a dedicated 'Multi Engineer.ini' in the Game Options directory.

Updated GameLobbyBase.ini to reference the new INI file for the Multi Engineer option.