### PR TITLE
Add npm dependencies caching to CI workflow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -37,6 +37,14 @@ jobs:
           submodules: true
           fetch-depth: 0 # required for gitversion
 
+      # Restore Tools NPM Libs from Cache
+      - name: Restore Tools NPM Libs from Cache
+        uses: actions/cache@v4
+        with:
+          path: tools/node_modules
+          key: ${{ runner.os }}-node-tools-${{ hashFiles('tools/package-lock.json', 'tools/package.json') }}
+          restore-keys: ${{ runner.os }}-node-tools-
+
       - name: Install Tools NPM Libs
         working-directory: tools
         run: npm ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install Tools NPM Libs
         working-directory: tools
-        run: npm install
+        run: npm ci
 
       # This looks for the latest release in our repo and does the following:
       # - updates our /live mirror path to point to it


### PR DESCRIPTION
Last time, in #757, I only handled the publish-release workflow, this PR also adds caching to the deploy workflow