### PR TITLE
Correctly obtain the installed game path in installer

### DIFF
--- a/tools/build-installer/inno/installer.twig
+++ b/tools/build-installer/inno/installer.twig
@@ -199,11 +199,11 @@ function DefaultDir(Param: String): String;
 var
   gamepath: String;
 begin
-  gamepath:=ExtractFilePath(ExpandConstant('{reg:HKLM\{cm:GameRegEng},InstallPath|{cm:DefaultGamePathEng}}'));
+  gamepath:=ExtractFilePath(ExpandConstant('{reg:HKLM32\{cm:GameRegEng},InstallPath|{cm:DefaultGamePathEng}}'));
   if (not FileExists(gamepath+ExpandConstant('\{cm:CheckFile}'))) then
-    gamepath:=ExpandConstant('{reg:HKLM\{cm:TFDReg},r2_folder|{pf}\{cm:TFDDirEnglish}}');
+    gamepath:=ExpandConstant('{reg:HKLM32\{cm:TFDReg},r2_folder|{pf}\{cm:TFDDirEnglish}}');
   if (not FileExists(gamepath+ExpandConstant('\{cm:CheckFile}'))) then
-    gamepath:=ExpandConstant('{reg:HKLM\{cm:OriginReg},Install Dir|{pf}\{cm:OriginDir}}');
+    gamepath:=ExpandConstant('{reg:HKLM32\{cm:OriginReg},Install Dir|{pf}\{cm:OriginDir}}');
   if (not FileExists(gamepath+ExpandConstant('\{cm:CheckFile}'))) then
     gamepath:=ExpandConstant('{pf}\{cm:TFDDirEnglish}');
   if (not FileExists(gamepath+ExpandConstant('\{cm:CheckFile}'))) then


### PR DESCRIPTION
Fix installer obtaining the game path.

<img width="998" height="752" alt="" src="https://github.com/user-attachments/assets/f384a534-65e8-4b07-98fe-9739b717db05" />

To test this PR: download installer from https://github.com/CnCNet/cncnet-yr-client-package/actions/runs/19594154010

Note: to simulate an RA2 installation on a different folder, download `ra2reg-yr.exe` from <https://github.com/SadPencil/Ra2Reg/releases/tag/v1.0>, place `ra2reg-yr.exe` file in RA2 folder and run it. Then, re-run the CnCNet YR installer. The installer should be able to find the installation path.