### PR TITLE
Add Weight Values to FV, MGTK, SCHD and HOWI

### DIFF
--- a/game-assets/cncnet.pack/rulesmd.ini
+++ b/game-assets/cncnet.pack/rulesmd.ini
@@ -7048,6 +7048,7 @@ Accelerates=false
 
 DeathWeapon=CRNuke ;GEF This will be a special case that only goes off if it's piloted by Ivan
 ElitePrimary=HoverMissileE
+Weight=3.5
 ;Bombable=no
 
 ; ********************************* IFV ************************************
@@ -7107,6 +7108,7 @@ Size=3
 AllowedToStartInMultiplayer=no
 EliteSecondary=MirageGunE
 CrushSound=TankCrush
+Weight=3.5
 
 ;Prism Tank
 [SREF]
@@ -7812,7 +7814,7 @@ EliteAbilities=SELF_HEAL,STRONGER,FIREPOWER,ROF
 Accelerates=false
 ImmuneToVeins=yes
 Size=3
-
+Weight=3.5
 
 ; **************************************************************************
 ; ******************************Soviet Units *******************************
@@ -11462,7 +11464,7 @@ UnloadingClass=SCHP
 Turret=yes
 DeployFire=yes
 DeployToLand=yes
-
+Weight=3.5
 
 ; Kirov Airship, Blimp
 [ZEP]

--- a/game-assets/ra2mode.pack/rulesmd.ini
+++ b/game-assets/ra2mode.pack/rulesmd.ini
@@ -6942,6 +6942,7 @@ ImmuneToVeins=yes
 Size=3
 AllowedToStartInMultiplayer=no
 EliteSecondary=MirageGunE
+Weight=3.5
 
 ;Infantry Fighting Vehicle - IFV
 [FV]
@@ -7133,6 +7134,7 @@ Accelerates=false
 
 DeathWeapon=CRNuke ;GEF This will be a special case that only goes off if it's piloted by Ivan
 ElitePrimary=HoverMissileE
+Weight=3.5
 ;Bombable=no
 
 
@@ -7222,6 +7224,7 @@ EliteAbilities=SELF_HEAL,STRONGER,FIREPOWER,ROF
 Accelerates=false
 ImmuneToVeins=yes
 Size=3
+Weight=3.5
 
 ; Armored Transport
 [SAPC]


### PR DESCRIPTION
These units _appear_ to be rolling over and flipping more often with Ares. 
Without Weight values defined the default value is 0.

`Weight=3.5` is the approximate value used for other units with very similar Strength and Armor values. 