### PR TITLE
Add Weight Values to MTNK, SCHP and TNKD

### DIFF
--- a/game-assets/cncnet.pack/rulesmd.ini
+++ b/game-assets/cncnet.pack/rulesmd.ini
@@ -6897,6 +6897,7 @@ Size=3
 OpportunityFire=yes
 ElitePrimary=105mmE
 BuildTimeMultiplier=1.5;Individual control of build time
+Weight=3.5
 
 ; **************************************************************************
 ; ********************************* IFV ************************************
@@ -7771,6 +7772,7 @@ Accelerates=false
 ImmuneToVeins=yes
 Size=3
 ElitePrimary=SABOTE
+Weight=3.5
 
 ; Howitzer
 [HOWI]
@@ -11200,6 +11202,7 @@ DeployFire=yes
 Turret=yes
 DeployToLand=yes
 IsSelectableCombatant=yes ; TR
+Weight=3.5
 
 ; Camera Dolly
 [DOLY]

--- a/game-assets/ra2mode.pack/rulesmd.ini
+++ b/game-assets/ra2mode.pack/rulesmd.ini
@@ -6889,7 +6889,7 @@ ImmuneToVeins=yes
 Size=3
 OpportunityFire=yes
 ElitePrimary=105mmE
-
+Weight=3.5
 
 ; Mirage Tank
 [MGTK]
@@ -7183,6 +7183,7 @@ Accelerates=false
 ImmuneToVeins=yes
 Size=3
 ElitePrimary=SABOTE
+Weight=3.5
 
 ; Howitzer
 [HOWI]


### PR DESCRIPTION
~MTNK to be consistent with Rhino/Lasher
~TNKD to be consistent with Tesla Tank
~SCHP so deployed Seige Choppers don't roll them self's