### PR TITLE
Switch to OpenGL backend for CnC-DDraw to fix desyncs temporarily, add GDI

### DIFF
--- a/package/Resources/Renderers.ini
+++ b/package/Resources/Renderers.ini
@@ -4,8 +4,10 @@
 [Renderers]
 0=Default
 1=CNC_DDRAW
+1GDI=CNC_DDRAW_GDI
 2=CNC_DDRAW_V4460
 3=CNC_DDRAW_stretch
+3GDI=CNC_DDRAW_stretch_GDI
 4=TS_DDRAW
 5=GDI
 6=DDWrapper
@@ -62,7 +64,18 @@ ResConfigFileName=gdi_ddraw.ini
 UseQres=false
 
 [CNC_DDRAW]
-UIName=CnC-DDraw
+UIName=CnC-DDraw (OpenGL)
+DLLName=cnc-ddraw.dll
+ConfigFileName=ddraw.ini
+ResConfigFileName=cnc-ddraw.ini
+WindowedModeSection=ddraw
+WindowedModeKey=windowed
+BorderlessWindowedModeKey=border
+IsBorderlessWindowedModeKeyReversed=true
+UseQres=false
+
+[CNC_DDRAW_GDI]
+UIName=CnC-DDraw (GDI)
 DLLName=cnc-ddraw.dll
 ConfigFileName=ddraw.ini
 ResConfigFileName=cnc-ddraw.ini
@@ -86,7 +99,18 @@ UseQres=false
 
 ; same as CNC_DDRAW, but always stretch to fullscreen
 [CNC_DDRAW_stretch]
-UIName=CnC-DDraw (stretch)
+UIName=CnC-DDraw (OpenGL, stretch)
+DLLName=cnc-ddraw.dll
+ConfigFileName=ddraw.ini
+ResConfigFileName=cnc-ddraw-stretch.ini; same with "cnc-ddraw.ini" except for "fullscreen=true"
+WindowedModeSection=ddraw
+WindowedModeKey=windowed
+BorderlessWindowedModeKey=border
+IsBorderlessWindowedModeKeyReversed=true
+UseQres=false
+
+[CNC_DDRAW_stretch_GDI]
+UIName=CnC-DDraw (GDI, stretch)
 DLLName=cnc-ddraw.dll
 ConfigFileName=ddraw.ini
 ResConfigFileName=cnc-ddraw-stretch.ini; same with "cnc-ddraw.ini" except for "fullscreen=true"

--- a/package/Resources/cnc-ddraw-stretch_gdi.ini
+++ b/package/Resources/cnc-ddraw-stretch_gdi.ini
@@ -48,7 +48,7 @@ posX=-32000
 posY=-32000
 
 ; Renderer, possible values: auto, opengl, openglcore, gdi, direct3d9, direct3d9on12 (auto = try direct3d9/opengl, fallback = gdi)
-renderer=opengl ; direct3d9 desyncs for some
+renderer=gdi
 
 ; Developer mode (don't lock the cursor)
 devmode=false

--- a/package/Resources/cnc-ddraw.ini
+++ b/package/Resources/cnc-ddraw.ini
@@ -48,7 +48,7 @@ posX=-32000
 posY=-32000
 
 ; Renderer, possible values: auto, opengl, openglcore, gdi, direct3d9, direct3d9on12 (auto = try direct3d9/opengl, fallback = gdi)
-renderer=auto
+renderer=opengl ; direct3d9 desyncs for some
 
 ; Developer mode (don't lock the cursor)
 devmode=false

--- a/package/Resources/cnc-ddraw_gdi.ini
+++ b/package/Resources/cnc-ddraw_gdi.ini
@@ -11,7 +11,7 @@ height=0
 
 ; Override the width/height settings shown above and always stretch to fullscreen
 ; Note: Can be combined with 'windowed=true' to get windowed-fullscreen aka borderless mode
-fullscreen=true
+fullscreen=false
 
 ; Run in windowed mode rather than going fullscreen
 windowed=false
@@ -48,7 +48,7 @@ posX=-32000
 posY=-32000
 
 ; Renderer, possible values: auto, opengl, openglcore, gdi, direct3d9, direct3d9on12 (auto = try direct3d9/opengl, fallback = gdi)
-renderer=opengl ; direct3d9 desyncs for some
+renderer=gdi
 
 ; Developer mode (don't lock the cursor)
 devmode=false


### PR DESCRIPTION
<img width="317" height="226" alt="image" src="https://github.com/user-attachments/assets/9374eaec-2dc6-4bc3-83bd-3fa04d4df437" />
