### PR TITLE
`.gitignore` improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,8 @@
 /package/movmd03.mix
 /package/multi.mix
 /package/multimd.mix
+/package/gamemd.exe
+/package/stats.dmp
 /package/QM/*.txt
 /package/Qt/QM/
 /package/ra2.mix
@@ -47,4 +49,15 @@
 /package.tar.gz
 /tools/node_modules
 /Client/
-package/Map Editor/FinalSun.ini
+/package/Map Editor/FinalSun.ini
+
+/package/cameo.mix
+/package/cameomd.mix
+/package/cncnet.fnt
+/package/game.fnt
+/package/grfxtxt.shp
+/package/ra2.csf
+/package/ra2md.csf
+/package/stringtable00.csf
+/package/subtitle.txt
+/package/subtitlemd.txt

--- a/.gitignore
+++ b/.gitignore
@@ -23,7 +23,6 @@
 /package/movmd03.mix
 /package/multi.mix
 /package/multimd.mix
-/package/gamemd.exe
 /package/stats.dmp
 /package/QM/*.txt
 /package/Qt/QM/

--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,6 @@
 /package/grfxtxt.shp
 /package/ra2.csf
 /package/ra2md.csf
-/package/stringtable00.csf
+/package/stringtable*.csf
 /package/subtitle.txt
 /package/subtitlemd.txt


### PR DESCRIPTION
The presence of these files often requires manually ignoring them during Git operations, which should be a process that can be simplified.
I hope to hear about potential issues that may arise from adding the following files to `.gitignore`:
- `/package/stats.dmp`
  - This is the dmp file automatically created by `CnCNet-Spawner.dll`. I think it is meaningless to keep checking it.
- Translation files:
  - Currently have these:
    <details open>
      <summary>Click to show</summary>

      - `/package/cameo.mix`
      - `/package/cameomd.mix`
      - `/package/cncnet.fnt`
      - `/package/game.fnt`
      - `/package/grfxtxt.shp`
      - `/package/ra2.csf`
      - `/package/ra2md.csf`
      - `/package/stringtable*.csf`
      - `/package/subtitle.txt`
      - `/package/subtitlemd.txt`

    </details>
  - These are the translation files we are currently using. They exist in `\package\Resources\Translations\<language>\`. When switching languages, they are moved to `.\package`, which causes Git to think that there are many new unstaged file changes in the directory whenever we switch languages.

In summary, not only do they require more effort each time to manually prevent them from being included in commits, but there is also the potential risk of inexperienced contributors mistakenly pushing them in the future. Therefore, without causing adverse effects, I hope to ignore these files in the `.\package` directory.