### PR TITLE
Clean up and reorganize Yuri's Revenge Rebalanced 2.1 patch

### DIFF
--- a/package/INI/Game Options/Yuri Rebalance Patch.ini
+++ b/package/INI/Game Options/Yuri Rebalance Patch.ini
@@ -128,7 +128,6 @@ ThreatAvoidanceCoefficient=0    ;1
 Soylent=1
 
 ; Apcalypse tank is now able to shoot while moving.
-; Increased Apocalypse tank's  anti-air weapon shots from 2 to 4.
 ; Apolcalypse tanks cannot be crushed by Battle Fortress
 [APOC]
 OpportunityFire=yes ;no
@@ -178,7 +177,6 @@ Soylent=200 ;250
 [YURI]
 OpenTransportWeapon=1
 
-; Grinding values of all vehicles reduced by 50%.
 ; Reduced Chaos Drone's cost from 1000 to 800.
 [CAOS]
 Cost=800 ;1000
@@ -340,10 +338,8 @@ EliteSecondary=TeslaFragmentE
 ;===  LYBIA  ========================================================
 
 ; Increased Demolition Truck speed to 6
-; Demo truck with size 6 cannot be lifted by non-elite magnetron
 [DTRUCK]
 Speed=6     ;5
-Size=6      ;3
 
 ; Increased Demolition Truck damage vs medium vehicle armor by 50%.
 ; Increased Demolition Truck damage vs heavy vehicle armor by 15%.

--- a/package/INI/Game Options/Yuri Rebalance Patch.ini
+++ b/package/INI/Game Options/Yuri Rebalance Patch.ini
@@ -66,10 +66,6 @@ SubjectToWalls=no
 [GGI]
 Speed=4
 
-;Fix bug with elite chrono legionnaire that did not let it shoot over walls
-[NeutronRifleE]
-Projectile=InvisibleMedium      ;InvisibleLow
-
 ; Elite IFV burst reduced from 4 to 2 to fix the infinite rate of fire exploit
 ; Elite IFV dmg increased to compensate for reduced burst
 [HoverMissileE]

--- a/package/INI/Game Options/Yuri Rebalance Patch.ini
+++ b/package/INI/Game Options/Yuri Rebalance Patch.ini
@@ -11,6 +11,13 @@ CMislEliteWarhead=CMISLEWH
 
 ;===  ALLIED  =======================================================
 
+; Allied Miner no longer avoids enemy units
+[CMON]
+ThreatAvoidanceCoefficient=0    ;1
+
+[CMIN]
+ThreatAvoidanceCoefficient=0    ;1
+
 ; Reduced the cost of the Allied power plant from 800 to 600.
 ; Reduced the selling refund value of the Allied power plant from 400 to 300.
 [GAPOWR]
@@ -40,13 +47,6 @@ Projectile=GGIP     ;AAHeatSeeker2
 ; GGI IFV missile weapon change to custom projectile to differentiate from IFV projectile
 [CRMissileLauncher]
 Projectile=GGIP     ;AAHeatSeeker2
-
-; Allied Miner no longer avoids enemy units
-[CMON]
-ThreatAvoidanceCoefficient=0    ;1
-
-[CMIN]
-ThreatAvoidanceCoefficient=0    ;1
 
 ; Custom GGI missile projectile
 [GGIP]
@@ -80,25 +80,6 @@ Burst=2        ;4
 [CLEG]
 Cost=1200       ;1500
 Soylent=600     ;750
-
-; Tank destroyer movement speed increased by 1
-[TNKD]
-Name=Tank Destroyer
-Speed=6   ;5
-ROT=7      ;5
-
-; Tank Destroyer weapon range increased to match the rhino tank attack range
-[SABOT]
-Range=5.75     ;5
-
-; Tank Destroyer warhead does 100% damage to terror drones -- Previously a tank destroyer could not kill a terror drone, not it will one-shot a terror drone
-[UltraAP]
-Verses=2%,2%,2%,100%,40%,100%,2%,2%,2%,100%,100%
-;2%,2%,2%,100%,40%,100%,2%,2%,2%,2%,100%
-
-[UltraAPE]
-Verses=2%,2%,2%,100%,50%,100%,2%,2%,2%,100%,100%
-;2%,2%,2%,100%,50%,100%,2%,2%,2%,100%,100%
 
 ; Disable robot tank requiring power to use
 [ROBO]
@@ -225,6 +206,27 @@ DominatorFireAtPercentage=90     ;20        ; Increased the delay of the Psychic
 DominatorCaptureRange=2          ;1         ; The mind control capture range increased by 1 to compensate for the delay
 
 ;===  COUNTRY SPECIFIC CHANGES  ========================================================
+
+;===  GERMANY  ========================================================
+
+; Tank destroyer movement speed increased by 1
+[TNKD]
+Name=Tank Destroyer
+Speed=6   ;5
+ROT=7      ;5
+
+; Tank Destroyer weapon range increased to match the rhino tank attack range
+[SABOT]
+Range=5.75     ;5
+
+; Tank Destroyer warhead does 100% damage to terror drones -- Previously a tank destroyer could not kill a terror drone, not it will one-shot a terror drone
+[UltraAP]
+Verses=2%,2%,2%,100%,40%,100%,2%,2%,2%,100%,100%
+;2%,2%,2%,100%,40%,100%,2%,2%,2%,2%,100%
+
+[UltraAPE]
+Verses=2%,2%,2%,100%,50%,100%,2%,2%,2%,100%,100%
+;2%,2%,2%,100%,50%,100%,2%,2%,2%,100%,100%
 
 ;===  GREAT BRITAIN  ========================================================
 


### PR DESCRIPTION
- Moved Tank Destroyer changes to the COUNTRY SPECIFIC CHANGES section under Germany, as it is a unique unit for Germany.
- Removed the change that increased the Demolition Truck's size to 6 to prevent it from being lifted by non-elite Magnetrons, as it does not work in the game.
- Removed the fix for elite chrono legionnaire that did not let it shoot over walls, as it has been fixed in the base rulesmd.ini file.