### PR TITLE
Yuri's Revenge Rebalanced 2.1.1 Update

### DIFF
--- a/package/INI/Game Options/Yuri Rebalance Patch.ini
+++ b/package/INI/Game Options/Yuri Rebalance Patch.ini
@@ -350,6 +350,10 @@ RadLevel=500 ;100
 
 ;===  IRAQ  ========================================================
 
+; Reduced Desolator speed from 4 to 3
+[DESO]
+Speed=3 ;4
+
 ;===  DOG LUCK & ANTI-ENGI-EATING  =======================================================
 
 ; Reduced rate of attacking of all Attack dogs to reduce dog luck.

--- a/package/INI/Game Options/Yuri Rebalance Patch.ini
+++ b/package/INI/Game Options/Yuri Rebalance Patch.ini
@@ -37,12 +37,16 @@ Arm=200     ;2
 Arm=200     ;2
 
 ; GGI missile weapon change to custom projectile to differentiate from IFV projectile
+; Reduced GGI missile weapon's range from 8 to 7
 [MissileLauncher]
 Projectile=GGIP     ;AAHeatSeeker2
+Range=7     ;8
 
 ; Elite GGI missile weapon change to custom projectile to differentiate from IFV projectile
+; Reduced Elite GGI missile weapon's range from 8 to 7
 [MissileLauncherE]
 Projectile=GGIP     ;AAHeatSeeker2
+Range=7     ;8
 
 ; GGI IFV missile weapon change to custom projectile to differentiate from IFV projectile
 [CRMissileLauncher]
@@ -62,9 +66,10 @@ SubjectToCliffs=no
 SubjectToElevation=no
 SubjectToWalls=no
 
-; Increased GGI speed from 3 to 4
+; Increased GGI extra air range from 0 to 2 (deployed)
 [GGI]
-Speed=4
+Soylent=200     ;150
+AirRangeBonus=2 ;not set
 
 ; Elite IFV burst reduced from 4 to 2 to fix the infinite rate of fire exploit
 ; Elite IFV dmg increased to compensate for reduced burst

--- a/package/INI/Game Options/Yuri Rebalance Patch.ini
+++ b/package/INI/Game Options/Yuri Rebalance Patch.ini
@@ -49,8 +49,14 @@ Projectile=GGIP     ;AAHeatSeeker2
 Range=7     ;8
 
 ; GGI IFV missile weapon change to custom projectile to differentiate from IFV projectile
+; Reduced GGI IFV missile weapon's range from 8 to 7
+; Burst of GGI IFV reduced to 1, but fires faster and hits harder
 [CRMissileLauncher]
 Projectile=GGIP     ;AAHeatSeeker2
+Damage=50       ;30
+ROF=30          ;40
+Range=7         ;8
+Burst=1         ;2
 
 ; Custom GGI missile projectile
 [GGIP]


### PR DESCRIPTION
- For a long time, Iraq has been the dominant force within the Soviet faction. As a result, the specific units of other Soviet sub-factions have been strengthened in previous updates. This update reduces the Desolator's movement speed, aiming to increase the pick rate of other Soviet sub-factions.
- With the weakening of the Desolator, the significant enhancements to the basic Allied soldiers in YR have become more prominent. This update rolls back previous improvements to the Guardian GI's movement speed, reduces its deployed range (from 8 to 7), but increases its range against aircraft (from 8 to 9).
- Simultaneously, the weapon of the GGI IFV have been adjusted to better align with the missile weapon configuration of the Guardian GI, enhancing its distinction from the weapon of the empty vehicle.