### PR TITLE
Add `-AFFINITY` command line argument

### DIFF
--- a/package/Resources/ClientDefinitions.ini
+++ b/package/Resources/ClientDefinitions.ini
@@ -18,7 +18,7 @@ GameExecutableNames=Syringe.exe
 ; Game executable name for Linux/Mac systems.
 UnixGameExecutableName=Resources/Compatibility/Unix/wine-game.sh
 ; Additional command line parameters applied after -SPAWN.
-ExtraCommandLineParams=-i=Ares.dll -i=CnCNet-Spawner.dll -i=Phobos.dll "gamemd-spawn.exe" -SPAWN -LOG -CD -RA2ModeSaveID=0x8d113b94
+ExtraCommandLineParams=-i=Ares.dll -i=CnCNet-Spawner.dll -i=Phobos.dll "gamemd-spawn.exe" -SPAWN -LOG -CD -RA2ModeSaveID=0x8d113b94 -AFFINITY:2
 
 SettingsFile=RA2MD.ini
 ConfigWindowTitle=YR Settings


### PR DESCRIPTION
Use the explicit Ares `-AFFINITY` command line to achieve the selection of processors [originally implemented](https://github.com/CnCNet/xna-cncnet-client/blob/develop/ClientGUI/GameProcessLogic.cs#L116) by the client.

