### PR TITLE
Add legacy update option

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -8,6 +8,7 @@ on:
     branches:
       - develop
       - pre-release
+      - legacy
       - feature/*
       - hotfix/*
 

--- a/package/Resources/Config/UpdaterConfig_Legacy.ini
+++ b/package/Resources/Config/UpdaterConfig_Legacy.ini
@@ -1,0 +1,6 @@
+; CnCNet developer Updateconfig.ini
+; Format: url, name, location
+
+https://downloads.cncnet.org/updates/games/yr/legacy/, CnCNet (developer updates), Europe
+
+

--- a/package/Resources/OptionsWindow.ini
+++ b/package/Resources/OptionsWindow.ini
@@ -147,8 +147,8 @@ Size=133,23
 
 [ddUpdateChannel]
 Location=102,238
-Size=97,21
-Items=Live,Pre-release,Dev
+Size=118,21
+Items=Live,Pre-release,Dev,Legacy (Unsupported)
 DefaultValue=0
 CheckFilePresence=yes
 ResetUnselectableItem=yes
@@ -157,6 +157,7 @@ RestartRequired=true
 Item0File0=Resources/Config/UpdaterConfig_Live.ini,updateconfig.ini,OverwriteOnMismatch
 Item1File0=Resources/Config/UpdaterConfig_PreRelease.ini,updateconfig.ini,OverwriteOnMismatch
 Item2File0=Resources/Config/UpdaterConfig_Dev.ini,updateconfig.ini,OverwriteOnMismatch
+Item3File0=Resources/Config/UpdaterConfig_Legacy.ini,updateconfig.ini,OverwriteOnMismatch
 ToolTip=Switch between update Channels. Requires client restart.
 Enabled=true
 

--- a/package/Resources/OptionsWindow.ini
+++ b/package/Resources/OptionsWindow.ini
@@ -147,7 +147,7 @@ Size=133,23
 
 [ddUpdateChannel]
 Location=102,238
-Size=118,21
+Size=135,21
 Items=Live,Pre-release,Dev,Legacy (Unsupported)
 DefaultValue=0
 CheckFilePresence=yes

--- a/package/updateexec
+++ b/package/updateexec
@@ -573,6 +573,7 @@ Resources\BinariesNET8\UniversalGL\DTAConfig.pdb
 Resources\BinariesNET8\XNA\DTAConfig.dll
 Resources\BinariesNET8\XNA\DTAConfig.pdb
 Maps\Custom\a488fba207efc7910d994a546d410b876bf2dfef.map
+Resources\Config\UpdaterConfig_Legacy.ini
 
 [DeleteFolder]
 Maps\Yuri's Revenge\CTF

--- a/package/updateexec
+++ b/package/updateexec
@@ -573,7 +573,6 @@ Resources\BinariesNET8\UniversalGL\DTAConfig.pdb
 Resources\BinariesNET8\XNA\DTAConfig.dll
 Resources\BinariesNET8\XNA\DTAConfig.pdb
 Maps\Custom\a488fba207efc7910d994a546d410b876bf2dfef.map
-Resources\Config\UpdaterConfig_Legacy.ini
 
 [DeleteFolder]
 Maps\Yuri's Revenge\CTF


### PR DESCRIPTION
Adds a legacy update channel to revert back to pre Ares/Phobos (version 8.76.2) - unsupported. 