### PR TITLE
Remove beta update from legacy

### DIFF
--- a/package/Resources/OptionsWindow.ini
+++ b/package/Resources/OptionsWindow.ini
@@ -23,7 +23,7 @@ Size=133,23
 [ddUpdateChannel]
 Location=102,238
 Size=97,21
-Items=Live,Pre-release,Dev,Beta (Ares)
+Items=Live,Pre-release,Dev
 DefaultValue=0
 CheckFilePresence=yes
 ResetUnselectableItem=yes
@@ -32,7 +32,6 @@ RestartRequired=true
 Item0File0=Resources/Config/UpdaterConfig_Live.ini,updateconfig.ini,OverwriteOnMismatch
 Item1File0=Resources/Config/UpdaterConfig_PreRelease.ini,updateconfig.ini,OverwriteOnMismatch
 Item2File0=Resources/Config/UpdaterConfig_Dev.ini,updateconfig.ini,OverwriteOnMismatch
-Item3File0=Resources/Config/UpdaterConfig_Ares.ini,updateconfig.ini,OverwriteOnMismatch
 ToolTip=Switch between update Channels. Requires client restart.
 Enabled=true
 

--- a/package/updateexec
+++ b/package/updateexec
@@ -579,6 +579,7 @@ Resources\BinariesNET8\UniversalGL\DTAConfig.dll
 Resources\BinariesNET8\UniversalGL\DTAConfig.pdb
 Resources\BinariesNET8\XNA\DTAConfig.dll
 Resources\BinariesNET8\XNA\DTAConfig.pdb
+Resources\Config\UpdaterConfig_Ares.ini
 
 [DeleteFolder]
 Maps\Yuri's Revenge\CTF


### PR DESCRIPTION
Removes the Ares update option in the legacy build