### PR TITLE
Update the version number of the Phobos Engine Extension

### DIFF
--- a/package/Resources/GameLobbyBase.ini
+++ b/package/Resources/GameLobbyBase.ini
@@ -597,8 +597,8 @@ IdleTexture=logo-2.png
 HoverTexture=logo-2.png
 DrawMode=Stretched
 DrawBorders=false
-URL=https://phobos.readthedocs.io/en/v0.4/index.html
-ToolTip=Ares-compatible C&C Red Alert 2: Yuri's Revenge engine extension@@Version: 0.4
+URL=https://phobos.readthedocs.io/en/v0.4.0.1/index.html
+ToolTip=Ares-compatible C&C Red Alert 2: Yuri's Revenge engine extension@@Version: 0.4.0.1
 $X=getRight(btnCnCNet) + EMPTY_SPACE_SIDES
 $Y=getY(btnCnCNet)
 

--- a/package/Resources/MainMenu.ini
+++ b/package/Resources/MainMenu.ini
@@ -240,6 +240,6 @@ IdleTexture=logo-2.png
 HoverTexture=logo-2.png
 DrawMode=Stretched
 DrawBorders=false
-URL=https://phobos.readthedocs.io/en/v0.4/index.html
-ToolTip=Ares-compatible C&C Red Alert 2: Yuri's Revenge engine extension@@Version: 0.4
+URL=https://phobos.readthedocs.io/en/v0.4.0.1/index.html
+ToolTip=Ares-compatible C&C Red Alert 2: Yuri's Revenge engine extension@@Version: 0.4.0.1
 ; do not remove last line of file

--- a/package/Resources/Translations/zh-Hans/Translation.ini
+++ b/package/Resources/Translations/zh-Hans/Translation.ini
@@ -1751,10 +1751,10 @@ INI:Controls:MainMenu:btnNewCampaign:Text=战役
 ; Campaign
 INI:Controls:MainMenu:btnOptions:Text=设置
 ; Options
-INI:Controls:MainMenu:btnPhobos:ToolTip=兼容 Ares 的《命令与征服：红色警戒 2 尤里的复仇》引擎扩展@@版本: 0.4
-; Ares-compatible C&C Red Alert 2: Yuri's Revenge engine extension@@Version: 0.4
-INI:Controls:MainMenu:btnPhobos:URL=https://phobos.readthedocs.io/zh-cn/v0.4/
-; https://phobos.readthedocs.io/en/v0.4/index.html
+INI:Controls:MainMenu:btnPhobos:ToolTip=兼容 Ares 的《命令与征服：红色警戒 2 尤里的复仇》引擎扩展@@版本: 0.4.0.1
+; Ares-compatible C&C Red Alert 2: Yuri's Revenge engine extension@@Version: 0.4.0.1
+INI:Controls:MainMenu:btnPhobos:URL=https://phobos.readthedocs.io/zh-cn/v0.4.0.1/
+; https://phobos.readthedocs.io/en/v0.4.0.1/index.html
 INI:Controls:MainMenu:btnProfiles:Text=查看天梯
 ; View Ladder
 INI:Controls:MainMenu:btnQuickmatch:Text=排位赛
@@ -1777,10 +1777,10 @@ INI:Controls:MultiplayerGameLobby:btnLaunchGame:Text=启动游戏
 ; Launch Game
 INI:Controls:MultiplayerGameLobby:btnLeaveGame:Text=离开游戏
 ; Leave Game
-INI:Controls:MultiplayerGameLobby:btnPhobos:ToolTip=兼容 Ares 的《命令与征服：红色警戒 2 尤里的复仇》引擎扩展@@版本: 0.4
-; Ares-compatible C&C Red Alert 2: Yuri's Revenge engine extension@@Version: 0.4
-INI:Controls:MultiplayerGameLobby:btnPhobos:URL=https://phobos.readthedocs.io/zh-cn/v0.4/
-; https://phobos.readthedocs.io/en/v0.4/index.html
+INI:Controls:MultiplayerGameLobby:btnPhobos:ToolTip=兼容 Ares 的《命令与征服：红色警戒 2 尤里的复仇》引擎扩展@@版本: 0.4.0.1
+; Ares-compatible C&C Red Alert 2: Yuri's Revenge engine extension@@Version: 0.4.0.1
+INI:Controls:MultiplayerGameLobby:btnPhobos:URL=https://phobos.readthedocs.io/zh-cn/v0.4.0.1/
+; https://phobos.readthedocs.io/en/v0.4.0.1/index.html
 INI:Controls:MultiplayerGameLobby:btnPickRandomMap:Text=随机选择地图
 ; Pick Random Map
 INI:Controls:MultiplayerGameLobby:chkAutoReady:Text=自动准备
@@ -1815,10 +1815,10 @@ INI:Controls:SkirmishLobby:btnLaunchGame:Text=启动游戏
 ; Launch Game
 INI:Controls:SkirmishLobby:btnLeaveGame:Text=离开游戏
 ; Leave Game
-INI:Controls:SkirmishLobby:btnPhobos:ToolTip=兼容 Ares 的《命令与征服：红色警戒 2 尤里的复仇》引擎扩展@@版本: 0.4
-; Ares-compatible C&C Red Alert 2: Yuri's Revenge engine extension@@Version: 0.4
-INI:Controls:SkirmishLobby:btnPhobos:URL=https://phobos.readthedocs.io/zh-cn/v0.4/
-; https://phobos.readthedocs.io/en/v0.4/index.html
+INI:Controls:SkirmishLobby:btnPhobos:ToolTip=兼容 Ares 的《命令与征服：红色警戒 2 尤里的复仇》引擎扩展@@版本: 0.4.0.1
+; Ares-compatible C&C Red Alert 2: Yuri's Revenge engine extension@@Version: 0.4.0.1
+INI:Controls:SkirmishLobby:btnPhobos:URL=https://phobos.readthedocs.io/zh-cn/v0.4.0.1/
+; https://phobos.readthedocs.io/en/v0.4.0.1/index.html
 INI:Controls:SkirmishLobby:btnPickRandomMap:Text=随机选择地图
 ; Pick Random Map
 INI:Controls:SkirmishLobby:chkAutoSave:Text=自动保存


### PR DESCRIPTION
The DLL file of the engine extension has already been updated in #782, but the version number displayed to users in the client has not been updated in a timely and synchronized manner.