### PR TITLE
Synchronize RA2 and YR Superweapon List

### DIFF
--- a/game-assets/ra2mode.pack/rulesmd.ini
+++ b/game-assets/ra2mode.pack/rulesmd.ini
@@ -2764,6 +2764,11 @@ Mutant=Special
 5=ChronoWarpSpecial
 6=ParaDropSpecial
 7=AmericanParaDropSpecial
+8=DummySW1
+9=DummySW2
+10=DummySW3
+11=DummySW4
+12=DummySW5
 
 ; *** Warhead List **
 ; This is a list of the various types of warheads available in the game
@@ -25746,6 +25751,81 @@ Action=AmerParaDrop
 SidebarImage=APARICON
 ShowTimer=no
 DisableableFromShell=no ; gs this determines which superweapons are turned off by the checkbox
+
+[DummySW1]
+UIName=Name:Do Not Use
+Name=Do Not Use
+IsPowered=false
+RechargeVoice=
+ChargingVoice=
+ImpatientVoice=
+SuspendVoice=
+RechargeTime=
+Type=AmerParaDrop
+Action=Custom
+SidebarImage=
+ShowTimer=no
+DisableableFromShell=no
+
+[DummySW2]
+UIName=Name:Do Not Use
+Name=Do Not Use
+IsPowered=false
+RechargeVoice=
+ChargingVoice=
+ImpatientVoice=
+SuspendVoice=
+RechargeTime=
+Type=AmerParaDrop
+Action=Custom
+SidebarImage=
+ShowTimer=no
+DisableableFromShell=no
+
+[DummySW3]
+UIName=Name:Do Not Use
+Name=Do Not Use
+IsPowered=false
+RechargeVoice=
+ChargingVoice=
+ImpatientVoice=
+SuspendVoice=
+RechargeTime=
+Type=AmerParaDrop
+Action=Custom
+SidebarImage=
+ShowTimer=no
+DisableableFromShell=no
+
+[DummySW4]
+UIName=Name:Do Not Use
+Name=Do Not Use
+IsPowered=false
+RechargeVoice=
+ChargingVoice=
+ImpatientVoice=
+SuspendVoice=
+RechargeTime=
+Type=AmerParaDrop
+Action=Custom
+SidebarImage=
+ShowTimer=no
+DisableableFromShell=no
+
+[DummySW5]
+UIName=Name:Do Not Use
+Name=Do Not Use
+IsPowered=false
+RechargeVoice=
+ChargingVoice=
+ImpatientVoice=
+SuspendVoice=
+RechargeTime=
+Type=AmerParaDrop
+Action=Custom
+SidebarImage=
+ShowTimer=no
+DisableableFromShell=no
 
 ;[HuntSeekSpecial]
 ;Name=Hunter Seeker


### PR DESCRIPTION
Added five dummy superweapon entries with placeholder values to make any superweapons added through .map files be the same index for trigger actions.

Currently the index is different for RA2mode in comparison to YR which causes a crash when using a trigger to fire a SW