### PR TITLE
Tweak Crimson Color

### DIFF
--- a/game-assets/cncnet.pack/rulesmd.ini
+++ b/game-assets/cncnet.pack/rulesmd.ini
@@ -3646,7 +3646,6 @@ Purple2=211,201,189
 Purple3=191,201,189
 
 ; New MP colors
-Crimson=255,255,180			; Crimson
 Brown=21,171,101			; Brown
 NewMagenta=215,230,250		; Magenta
 Teal=125,255,130			; Teal

--- a/game-assets/cncnet.pack/rulesmd.ini
+++ b/game-assets/cncnet.pack/rulesmd.ini
@@ -3630,7 +3630,7 @@ Gold=43,239,255             ; Yellow
 LightGrey=0,0,240			; White
 Grey=0,0,131				; Grey
 Red=20,255,184				; Brown
-DarkRed=0,230,255			; Red
+DarkRed=5,255,225			; Red
 Orange=25,230,255			; Orange
 Magenta=221,102,255			; Pink
 Purple=201,201,189			; Purple
@@ -3646,6 +3646,7 @@ Purple2=211,201,189
 Purple3=191,201,189
 
 ; New MP colors
+Crimson=240,225,190			; Crimson
 Brown=21,171,101			; Brown
 NewMagenta=215,230,250		; Magenta
 Teal=125,255,130			; Teal
@@ -3659,7 +3660,7 @@ Pistachio=57,220,230        ; Pistachio
 AlliedLoad=164,255,255		; 17
 SovietLoad=0,235,255		; 18
 FirstText=153,214,212		; First Text
-SecondText=0,230,255		; Second Text
+SecondText=5,255,225		; Second Text
 
 ;This is the ColorAdd section
 ;These are the colors used to tint buildings, such as when they are designated for an Airstrike

--- a/game-assets/cncnet.pack/uimd.ini
+++ b/game-assets/cncnet.pack/uimd.ini
@@ -51,14 +51,17 @@ Slot7.ColorScheme=Purple
 Slot8.DisplayColor=255,156,239
 Slot8.ColorScheme=Magenta
 
-Slot9.DisplayColor=101,67,33
-Slot9.ColorScheme=Brown
+Slot9.DisplayColor=190,22,85
+Slot9.ColorScheme=Crimson
 
-Slot10.DisplayColor=250,25,250
-Slot10.ColorScheme=NewMagenta
+Slot10.DisplayColor=101,67,33
+Slot10.ColorScheme=Brown
 
-Slot11.DisplayColor=0,128,128
-Slot11.ColorScheme=Teal
+Slot11.DisplayColor=250,25,250
+Slot11.ColorScheme=NewMagenta
 
-Slot12.DisplayColor=180,250,40
-Slot12.ColorScheme=Pistachio
+Slot12.DisplayColor=0,128,128
+Slot12.ColorScheme=Teal
+
+Slot13.DisplayColor=180,250,40
+Slot13.ColorScheme=Pistachio

--- a/game-assets/cncnet.pack/uimd.ini
+++ b/game-assets/cncnet.pack/uimd.ini
@@ -51,17 +51,14 @@ Slot7.ColorScheme=Purple
 Slot8.DisplayColor=255,156,239
 Slot8.ColorScheme=Magenta
 
-Slot9.DisplayColor=180,10,90
-Slot9.ColorScheme=Crimson
+Slot9.DisplayColor=101,67,33
+Slot9.ColorScheme=Brown
 
-Slot10.DisplayColor=101,67,33
-Slot10.ColorScheme=Brown
+Slot10.DisplayColor=250,25,250
+Slot10.ColorScheme=NewMagenta
 
-Slot11.DisplayColor=250,25,250
-Slot11.ColorScheme=NewMagenta
+Slot11.DisplayColor=0,128,128
+Slot11.ColorScheme=Teal
 
-Slot12.DisplayColor=0,128,128
-Slot12.ColorScheme=Teal
-
-Slot13.DisplayColor=180,250,40
-Slot13.ColorScheme=Pistachio
+Slot12.DisplayColor=180,250,40
+Slot12.ColorScheme=Pistachio

--- a/game-assets/ra2mode.pack/rulesmd.ini
+++ b/game-assets/ra2mode.pack/rulesmd.ini
@@ -3244,7 +3244,6 @@ NeonGreen=0,0,0				    ; Black
 Yellow=38,159,255			    ; Pastel yellow
 
 ; New MP Colors
-Crimson=255,255,180				; Crimson
 Brown=21,171,101				; Brown
 NewMagenta=215,230,250			; Magenta
 Teal=125,255,130				; Teal

--- a/game-assets/ra2mode.pack/rulesmd.ini
+++ b/game-assets/ra2mode.pack/rulesmd.ini
@@ -3230,7 +3230,7 @@ Gold=41,240,230				    ; Yellow
 LightGrey=0,0,240			    ; White
 Grey=0,0,131				    ; Grey
 Red=20,255,184				    ; Brown
-DarkRed=0,230,255			    ; Red
+DarkRed=5,255,225			    ; Red
 Orange=25,230,255			    ; Orange
 Magenta=221,102,255			    ; Pink
 Purple=201,201,189			    ; Purple
@@ -3244,6 +3244,7 @@ NeonGreen=0,0,0				    ; Black
 Yellow=38,159,255			    ; Pastel yellow
 
 ; New MP Colors
+Crimson=240,225,190				; Crimson
 Brown=21,171,101				; Brown
 NewMagenta=215,230,250			; Magenta
 Teal=125,255,130				; Teal
@@ -3255,7 +3256,7 @@ Pistachio=57,220,230        	; Pistachio
 AlliedLoad=164,255,255		; 17
 SovietLoad=0,235,255		; 18
 FirstText=153,214,212		; First Text
-SecondText=0,230,255		; Second Text
+SecondText=5,255,225		; Second Text
 
 
 ; ******* Difficulty Settings *******

--- a/game-assets/ra2mode.pack/uimd.ini
+++ b/game-assets/ra2mode.pack/uimd.ini
@@ -51,14 +51,17 @@ Slot7.ColorScheme=Purple
 Slot8.DisplayColor=255,156,239
 Slot8.ColorScheme=Magenta
 
-Slot9.DisplayColor=101,67,33
-Slot9.ColorScheme=Brown
+Slot9.DisplayColor=190,22,85
+Slot9.ColorScheme=Crimson
 
-Slot10.DisplayColor=250,25,250
-Slot10.ColorScheme=NewMagenta
+Slot10.DisplayColor=101,67,33
+Slot10.ColorScheme=Brown
 
-Slot11.DisplayColor=0,128,128
-Slot11.ColorScheme=Teal
+Slot11.DisplayColor=250,25,250
+Slot11.ColorScheme=NewMagenta
 
-Slot12.DisplayColor=180,250,40
-Slot12.ColorScheme=Pistachio
+Slot12.DisplayColor=0,128,128
+Slot12.ColorScheme=Teal
+
+Slot13.DisplayColor=180,250,40
+Slot13.ColorScheme=Pistachio

--- a/game-assets/ra2mode.pack/uimd.ini
+++ b/game-assets/ra2mode.pack/uimd.ini
@@ -51,17 +51,14 @@ Slot7.ColorScheme=Purple
 Slot8.DisplayColor=255,156,239
 Slot8.ColorScheme=Magenta
 
-Slot9.DisplayColor=180,10,90
-Slot9.ColorScheme=Crimson
+Slot9.DisplayColor=101,67,33
+Slot9.ColorScheme=Brown
 
-Slot10.DisplayColor=101,67,33
-Slot10.ColorScheme=Brown
+Slot10.DisplayColor=250,25,250
+Slot10.ColorScheme=NewMagenta
 
-Slot11.DisplayColor=250,25,250
-Slot11.ColorScheme=NewMagenta
+Slot11.DisplayColor=0,128,128
+Slot11.ColorScheme=Teal
 
-Slot12.DisplayColor=0,128,128
-Slot12.ColorScheme=Teal
-
-Slot13.DisplayColor=180,250,40
-Slot13.ColorScheme=Pistachio
+Slot12.DisplayColor=180,250,40
+Slot12.ColorScheme=Pistachio

--- a/package/Resources/GameOptions.ini
+++ b/package/Resources/GameOptions.ini
@@ -26,10 +26,11 @@ Orange=255,165,24,4
 Cyan=49,214,231,5
 Purple=148,41,189,6
 Pink=255,156,239,7
-Brown=101,67,33,8
-Magenta=250,25,250,9
-Teal=0,128,128,10
-Pistachio=180,250,40,11
+Crimson=190,22,85,8
+Brown=101,67,33,9
+Magenta=250,25,250,10
+Teal=0,128,128,11
+Pistachio=180,250,40,12
 
 ; Keys that are ALWAYS written to spawn.ini when the game starts.
 ; These can be overriden by gamemode-specific code.

--- a/package/Resources/GameOptions.ini
+++ b/package/Resources/GameOptions.ini
@@ -26,11 +26,10 @@ Orange=255,165,24,4
 Cyan=49,214,231,5
 Purple=148,41,189,6
 Pink=255,156,239,7
-Crimson=180,10,90,8
-Brown=101,67,33,9
-Magenta=250,25,250,10
-Teal=0,128,128,11
-Pistachio=180,250,40,12
+Brown=101,67,33,8
+Magenta=250,25,250,9
+Teal=0,128,128,10
+Pistachio=180,250,40,11
 
 ; Keys that are ALWAYS written to spawn.ini when the game starts.
 ; These can be overriden by gamemode-specific code.


### PR DESCRIPTION
After more gameplay with others on dev build of client, it's determined crimson is far too similar to vanilla red. 
This tweaks crimson to distinguish between the colors more.