### PR TITLE
Remove chat components from skirmish lobby

### DIFF
--- a/package/Resources/GameLobbyBase.ini
+++ b/package/Resources/GameLobbyBase.ini
@@ -33,7 +33,6 @@ $CC14=lblGameModeSelect:XNALabel
 $CC15=btnPickRandomMap:XNAClientButton
 $CC16=tbMapSearch:XNASuggestionTextBox
 $CC17=PlayerExtraOptionsPanel:PlayerExtraOptionsPanel
-$CC18=lbChatMessages:ChatListBox
 $CC20=btnCnCNet:XNALinkButton
 $CC21=chkAutoSave:GameLobbyCheckBox
 $CC22=ractl:XNAExtraPanel

--- a/package/Resources/GameLobbyBase.ini
+++ b/package/Resources/GameLobbyBase.ini
@@ -34,7 +34,6 @@ $CC15=btnPickRandomMap:XNAClientButton
 $CC16=tbMapSearch:XNASuggestionTextBox
 $CC17=PlayerExtraOptionsPanel:PlayerExtraOptionsPanel
 $CC18=lbChatMessages:ChatListBox
-$CC19=tbChatInput:XNAChatTextBox
 $CC20=btnCnCNet:XNALinkButton
 $CC21=chkAutoSave:GameLobbyCheckBox
 $CC22=ractl:XNAExtraPanel

--- a/package/Resources/MultiplayerGameLobby.ini
+++ b/package/Resources/MultiplayerGameLobby.ini
@@ -19,6 +19,7 @@ TeamWidth=35
 ; controls
 $CCMP00=btnLockGame:XNAClientButton
 $CCMP01=chkAutoReady:XNAClientCheckBox
+$CCMP02=tbChatInput:XNAChatTextBox
 
 [lbMapList]
 $Height=291

--- a/package/Resources/MultiplayerGameLobby.ini
+++ b/package/Resources/MultiplayerGameLobby.ini
@@ -20,6 +20,7 @@ TeamWidth=35
 $CCMP00=btnLockGame:XNAClientButton
 $CCMP01=chkAutoReady:XNAClientCheckBox
 $CCMP02=tbChatInput:XNAChatTextBox
+$CCMP03=lbChatMessages:ChatListBox
 
 [lbMapList]
 $Height=291


### PR DESCRIPTION
Well, this component should not exist in Skirmish Lobby. Since [XNAUI v3.1.1](https://github.com/Rampastring/Rampastring.XNAUI/commit/f1995d550cb94cf8c4b12ae77af221e2471a882c), there is a chance that tbChatInput shows as a vertical bar in Skirmish Lobby -- but the border in CnCNet YR covers it so I didn't reproduce this display issue in CnCNet YR. The screenshot below is from Mental Omega

Better to remove this tbChatInput from Skirmish Lobby anyhow, in case it causes some trouble in the future.

<img width="811" height="237" alt="图片" src="https://github.com/user-attachments/assets/febc9769-48d3-46d1-a924-673c5adfaceb" />

