### PR TITLE
rulesmd.ini cleanup

### DIFF
--- a/game-assets/cncnet.pack/artmd.ini
+++ b/game-assets/cncnet.pack/artmd.ini
@@ -8171,7 +8171,7 @@ MuzzleFlash9=-41,40
 CanBeHidden=False
 OccupyHeight=4
 DamageFireOffset0=19,31
-damageFireOffset1=-43,25
+DamageFireOffset1=-43,25
 RemoveOccupy1=-2,0
 RemoveOccupy2=-2,1
 RemoveOccupy3=-2,2
@@ -8241,7 +8241,7 @@ ActiveAnim=NAPSYB_A
 ActiveAnimDamaged=NAPSYB_AD
 ActiveAnimZAdjust=-75
 ActiveAnimYSort=100
-CanBeHidden-False
+;CanBeHidden-False
 OccupyHeight=3
 RemoveOccupy1=0,-1
 RemoveOccupy2=-1,0
@@ -8514,7 +8514,7 @@ MuzzleFlash7=-34,2
 MuzzleFlash8=-31,55
 MuzzleFlash9=20,0
 DamageFireOffset0=100,-53
-DamageFireOffset0-37,33
+DamageFireOffset1=-37,33
 CanHideThings=true
 CanBeHidden=false
 OccupyHeight=7
@@ -11410,7 +11410,7 @@ DamageFireOffset0=40,30
 [CALA14]
 Normalized=yes
 Remapable=no
-Foundation=3X3
+Foundation=3x3
 Height=6
 ;Buildup=CAHOSP
 NewTheater=yes
@@ -11439,7 +11439,7 @@ DamageFireOffset1=-9,-27
 [CALA15]
 Normalized=yes
 Remapable=no
-Foundation=3X3
+Foundation=3x3
 Height=6
 ;Buildup=CAHOSP
 NewTheater=yes
@@ -14829,8 +14829,6 @@ Panic=8,6,6
 ; SpawnDelay = number of frames between anim spawns (def=3)
 ; AnimPalette = Does it use the animation palette palette (def=no)?
 [120MM]
-
-[PARABOMB]
 
 [MEDUSA]			; Aegis
 ;Trailer=DURASMOKE
@@ -19455,7 +19453,7 @@ YSortAdjust=-200
 [GTGCAN]
 Remapable=yes
 NewTheater=yes
-Cameo= GCANICON
+Cameo=GCANICON
 Foundation=2x2
 Height=3	; experiment with this
 Buildup=GTGCANMK

--- a/game-assets/cncnet.pack/rulesmd.ini
+++ b/game-assets/cncnet.pack/rulesmd.ini
@@ -223,7 +223,7 @@ PParatrooper=E1          ; infantry that is dropped as a paratrooper
 
 ChronoDelay=60			;delay after teleport for chrono sphere
 ChronoReinfDelay=180	;delay after teleport for chrono reinforcements
-ChronoDistanceFactor=48	;default = 32 amount to divide the distance to destination by to get the warped out delay
+ChronoDistanceFactor=48	;default=32 amount to divide the distance to destination by to get the warped out delay
 ChronoTrigger=yes		;defualt=yes, if yes, then delay varies by distance, if no, it's a constant
 ChronoMinimumDelay=16	;default=0;this is the minimum delay for teleporting, no matter how short the distance
 						;this value will also be used if the ChronoTrigger flag is turned off
@@ -277,7 +277,7 @@ SecretBuildings=GTGCAN
 AlliedDisguise=E1
 SovietDisguise=E2 ; these are the defaults for the spy if a MakeupKit hasn't been used
 ThirdDisguise=INIT
-SpyPowerBlackout=1000 ; Frame time a spy shuts down power for (900 = 1 minute)
+SpyPowerBlackout=1000 ; Frame time a spy shuts down power for (900=1 minute)
 SpyMoneyStealPercent=.5 ; Percent of total money you take with a spy
 
 ;DB Changed on 7/21/01 as part of the add-on.  What a silly person DB is.
@@ -371,7 +371,7 @@ TunnelSpeed=1
 MultipleFactory=0.8       ; Ick.  This is now a straight discount multiplier that is cumulative.  ie at .8 you get 1, .8, .64, .512 instead of 1, 1, 1.25,etc   ;gs factory bonus for multiples [1=full bonus, 0=no bonus] (def=1) <--their way at 1 you get 1, 1, .5, .33, .25, etc
 MinLowPowerProductionSpeed=.5   ; minimum production speed as result of low power (def=.5) ;gs applies after modifer below
 MaxLowPowerProductionSpeed=.8 ; and since most of the time you will be short by only 10 or 20, this is the maximum speed you can build if you have low power (so 99% power is treated as this %)
-LowPowerPenaltyModifier=1 ;gs "double penalty" or "half penalty".  multiply this by the power short to get the actual penalty ( def=1. 2 means 30% short = 60% penalty, .5 would mean 15% penalty.)
+LowPowerPenaltyModifier=1 ;gs "double penalty" or "half penalty".  multiply this by the power short to get the actual penalty ( def=1. 2 means 30% short=60% penalty, .5 would mean 15% penalty.)
 
 ; hack section
 GDIGateOne=GADUMY ;GEF GAGATE_A      ; these buildings affect nearby walls, so I need to know what they are
@@ -409,7 +409,7 @@ LeptonsPerSightIncrease=2000 ;how high does a unit have to go before it can see 
 LeptonsPerFireIncrease=2000 ; how high does a unit have to go before it can fire farther?
 AttackingAircraftSightRange=2 ; //gs 6 Makes the V3 ping the map.  Hi, welcome to dumb ideas.
 BlendedFog=yes          ; should we blend the fog (as opposed to dither it)
-CliffBackImpassability=2 ; how impassable is it behind cliffs? (0 = minimal, 2 = maximal)
+CliffBackImpassability=2 ; how impassable is it behind cliffs? (0=minimal, 2=maximal)
 IceCrackingWeight=50.0   ; objects weighing more than this will crack ice
 IceBreakingWeight=50.0   ; objects weighing more than this well break through ice
 ShipSinkingWeight=3.0	; Surface ships of this or greater weight will sink, not explode, when destroyed.
@@ -617,9 +617,9 @@ OreTwinkleChance=30                   ; At map startup, there is 1 chance in N t
 CreateInfantrySound=	; default sound to use when a new infantry person is created
 CreateUnitSound=				; default sound to use when a new unit is created
 CreateAircraftSound=		; default sound to use when a new aircraft is created
-;IFVTransformSound= IFVTransform	; sound to use when a IFV changes turret ; use EnterTransportSound instead
-SpySatActivationSound= SpyUplinkOn ;	sound to play when spysat comes online
-SpySatDeactivationSound= SpyUplinkOff ;	sound to play when spysat goes offline
+;IFVTransformSound=IFVTransform	; sound to use when a IFV changes turret ; use EnterTransportSound instead
+SpySatActivationSound=SpyUplinkOn ;	sound to play when spysat comes online
+SpySatDeactivationSound=SpyUplinkOff ;	sound to play when spysat goes offline
 ;PsychicSensorDetectAttach=	PsychicSensorDetects ;sound to play when sensor detects an attack (not hooked up yet)
 UpgradeVeteranSound=UpgradeVeteran
 UpgradeEliteSound=UpgradeElite
@@ -631,7 +631,7 @@ PlaceBeaconSound=BeaconPlaced
 
 ;GEF Used to make the damage from the brute rock the target more than it normally would.
 DirectRockingCoefficient=1.5
-FallBackCoefficient=0.1	;GEF Used to reduce the amount the tank falls back between pushes. Smaller number = less fallback
+FallBackCoefficient=0.1	;GEF Used to reduce the amount the tank falls back between pushes. Smaller number=less fallback
 
 ;GEF which color should buildings get colored when they are targeted by a laser designator?
 ;Look at the ColorAdd section for references
@@ -710,7 +710,7 @@ MovieOn=MovieOn         ; movie activation sound
 MovieOff=MovieOff       ; movie deactivation sound
 ScoldSound=MenuScold       ; generic scold sound
 TeslaCharge=TeslaCoilPowerUp    ; tesla charge up sound
-TeslaZap=       ; tesla zap sound
+TeslaZap=; tesla zap sound
 BuildingDamageSound=BuildingDamaged    ; sound when building is damaged to half strength
 ChuteSound=ParachuteDrop         ; parachute deploy sound
 GenericClick=MenuClick    ; generic click sound
@@ -722,34 +722,34 @@ ScatterSound=CommandBar		;Sound when units are commanded to scatter
 DeploySound=		;Sound when units are commanded to deploy
 StormSound=WeatherIntro		; PCG. Sound when weather controller storm starts.
 LightningSounds=WeatherStrike ; PCG. Sounds for various lightning bolts.
-ShellButtonSlideSound= ; PCG; Sound for the shell buttons sliding into position.
+ShellButtonSlideSound=; PCG; Sound for the shell buttons sliding into position.
 
 ; New Sound hooks for Mission disk - TR
-VoiceIFVRepair= IFVMove ; Reponse to repair command
-SlavesFreeSound= SlaveWorkerLiberated	; sound made when miner slaves are freed
-SlaveMinerDeploySound= SlaveMinerDeploy
-SlaveMinerUndeploySound= SlaveMinerDeploy
-BunkerWallsUpSound= TankBunkerUp
-BunkerWallsDownSound= TankBunkerDown
-RepairBridgeSound= BridgeRepaired
+VoiceIFVRepair=IFVMove ; Reponse to repair command
+SlavesFreeSound=SlaveWorkerLiberated	; sound made when miner slaves are freed
+SlaveMinerDeploySound=SlaveMinerDeploy
+SlaveMinerUndeploySound=SlaveMinerDeploy
+BunkerWallsUpSound=TankBunkerUp
+BunkerWallsDownSound=TankBunkerDown
+RepairBridgeSound=BridgeRepaired
 PsychicDominatorActivateSound=PsychicDominatorActivate
 GeneticMutatorActivateSound=GeneticMutatorActivate
 PsychicRevealActivateSound=PsychicRevealActivate
-MasterMindOverloadDeathSound= MasterMindOverloadVoice
+MasterMindOverloadDeathSound=MasterMindOverloadVoice
 MindClearedSound=	MindCleared;default sound to play for units that are released from mind control
-EnterGrinderSound= GrinderGrinding	; default sound to play when a unit enters the grinder building
+EnterGrinderSound=GrinderGrinding	; default sound to play when a unit enters the grinder building
 LeaveGrinderSound=	; default sound to play when a unit leaves the grinder building
-EnterBioReactorSound= BioReactorEnter	; default sound to play when a unit enters the bio reactor building
-LeaveBioReactorSound= BioReactorEnter	; default sound to play when a unit leaves the bio reactor building
+EnterBioReactorSound=BioReactorEnter	; default sound to play when a unit enters the bio reactor building
+LeaveBioReactorSound=BioReactorEnter	; default sound to play when a unit leaves the bio reactor building
 ActivateSound=	; default sound to play for units that are activated
 DeactivateSound=	;default soudn to play when units are deactivated
 AirstrikeAbortSound=MIGMissionAborted
 AirstrikeAttackVoice=MIGMove
 SpyPlaneCamera=SpyPlaneSnapshot;gs this is played each time the plane looks, which is every spycameraframes below
 SpyPlaneCameraFrames=16;gs while in the process of taking pictures, how often to play the sound
-DiskLaserChargeUp= FloatingDiscChargeUp ;gs the Report on DiskLaser will sound at the end of the ring, this will play at the beginning
-LetsDoTheTimeWarpOutAgain = ChronoScreenSound; sound for time shift out sequence	 (can be looping)
-LetsDoTheTimeWarpInAgain = ChronoScreenSoundAgain; sound for time shift in sequence	 (can be looping)
+DiskLaserChargeUp=FloatingDiscChargeUp ;gs the Report on DiskLaser will sound at the end of the ring, this will play at the beginning
+LetsDoTheTimeWarpOutAgain=ChronoScreenSound; sound for time shift out sequence	 (can be looping)
+LetsDoTheTimeWarpInAgain=ChronoScreenSoundAgain; sound for time shift in sequence	 (can be looping)
 
 Smoke=xxxx           ; smoke that rises from the ground after a building explosion
 ;GEF FirestormActiveAnim=GAFSDF_A
@@ -832,8 +832,8 @@ Scorches1=BURN05,BURN06,BURN07 ; scorch mark smudge types
 Scorches2=BURN08,BURN09,BURN10 ; scorch mark smudge types
 Scorches3=BURN11,BURN12,BURN13 ; scorch mark smudge types
 Scorches4=BURN14,BURN15,BURN16 ; scorch mark smudge types
-TiberiumExplosionDamage = 0 ; the amount of damage dealt out by explosion in a big tiberium chain reaction
-TiberiumStrength = -1 ;	the higher this value, the harder it is to get big tiberium to explode
+TiberiumExplosionDamage=0 ; the amount of damage dealt out by explosion in a big tiberium chain reaction
+TiberiumStrength=-1 ;	the higher this value, the harder it is to get big tiberium to explode
 Craters=CR1,CR2,CR3,CR4,CR5,CR6   ; crater smudge types
 AtomDamage=1000      ; damage points when nuclear bomb explodes (regardless of source)
 BallisticScatter=1.0 ; maximum scatter distance (cells) for inaccurate ballistic projectiles (Note: Flak Cannon uses this)
@@ -933,7 +933,7 @@ CollapseChance=100      ; Percent chance that a cliff will collapse when hit.
 BerzerkAllowed=no       ; Allow Cyborgs to go berzerk when at half damage?
 
 
-// PCG; Provides knobs to tweak for radiation used by desolater and friends.
+; PCG; Provides knobs to tweak for radiation used by desolater and friends.
 [Radiation]
 RadDurationMultiple=1		; Number of frames site lasts per level of radiation.
 							; When rad level goes to zero, rad site deletes itself.
@@ -957,7 +957,7 @@ RadColor=0,255,0			; The color of the radiation.
 RadSiteWarhead=RadSite		; Sets the warhead used by irradiated tiles.
 
 
-// PCG; Enables customization of the effects elevation has on firing.
+; PCG; Enables customization of the effects elevation has on firing.
 [ElevationModel]
 ElevationIncrement=4			; Number of levels between source and target for a range bonus to kick in.
 ElevationIncrementBonus=2		; Amount of range bonus to add for each elevation increment (NOT map level) between source and target.
@@ -966,7 +966,7 @@ ElevationIncrementBonus=2		; Amount of range bonus to add for each elevation inc
 								; source and target.
 ElevationBonusCap=2				; Cap on range bonuses, to prevent increased average scanning cost for rare situations.
 
-// PCG; Enables customization of the effects walls have on shots.
+; PCG; Enables customization of the effects walls have on shots.
 [WallModel]
 AlliedWallTransparency=no		; If this is yes, allied walls have no effect on the shots of allied units.
 WallPenetratorThreshold=50%		; The amount of damage a unit must inflict before it attempts to fire through walls between it and its target.
@@ -1943,7 +1943,7 @@ Mutant=Special
 180=TROCK05
 181=VEINHOLEDUMMY
 182=CRATE
-;GEF french wall being taken out 183=GAFWLL ;gs Needs own art since an Image= will negate the different stats
+;GEF french wall being taken out 183=GAFWLL ;gs Needs own art since an Image=will negate the different stats
 184=FENCE01
 185=FENCE02
 186=FENCE03
@@ -2534,8 +2534,11 @@ Mutant=Special
 ;840=CAPARS11D
 841=CAPARS12D
 
-842-GAWETH_ED
-843-GAWETH_GD
+; Fixed 842 and 843 by redeclaring at end of list
+; - dont want to mess up any animation indexing for map triggers
+; - RAZER
+;842-GAWETH_ED
+;843-GAWETH_GD
 
 844=CACHIG04D
 
@@ -2811,6 +2814,9 @@ Mutant=Special
 1070=YAPOWR_BD
 1071=YAPOWR_CD
 1072=CANKFGL_A; CCCP84 Nov 2025: it was in unused files. added to ini files and shp to the mix
+
+1073=GAWETH_ED
+1074=GAWETH_GD
 
 ; belonit - additions needed for Ares
 1200=D
@@ -3243,32 +3249,32 @@ Mutant=Special
 ; PCG; 05/02/2K; Added a bunch of stuff to this to try to get everything
 ; controllable from one place.
 ;
-; MinMoney = minimum amount of money selectable in the slider. (def=2500)
-; Money = default amount of money that shows up on the slider. (def=10000)
-; MaxMoney = maximum amount of money selectable in the slider. (def=10000)
-; MoneyIncrement = the amount of money that changes when the slider position
+; MinMoney=minimum amount of money selectable in the slider. (def=2500)
+; Money=default amount of money that shows up on the slider. (def=10000)
+; MaxMoney=maximum amount of money selectable in the slider. (def=10000)
+; MoneyIncrement=the amount of money that changes when the slider position
 ;                  changes its minimum amount. (def=100)
-; MinUnitCount = minumum number of starting units in a game. (def=1)
-; UnitCount = the default starting units. (def=10)
-; MaxUnitCount = maximum number of starting units. (def=20)
-; TechLevel = maximum tech level achievable in a game. (def=10)
-; GameSpeed = starting game speed. For some wacky reason, 0=fastest, 6=slowest. (def=0)
-; AIDifficulty = starting AI difficulty. (def=1)  (0=easy, 1=normal, 2=hard)
-; AIPlayers = starting number of AI players.  Always at least 1 for skirmish.  (def=0)
-; BridgeDestruction = can bridges be destroyed? (def=true)
-; ShadowGrow = deos the shroud regrow? (def=no)  DESUPPORTED.
-; Shroud = is there a shroud on the map? (def=yes)  NOT YET SUPPORTED.
-; Bases = can you build buildings or is this just a unit-to-unit slugfest. (def=yes)  DESUPPORTED.
-; TiberiumGrows = does ore/tiberium/whatever regenerate? (def=yes)
-; Crates = do crates appear in the game? (def=yes)
-; CaptureTheFlag = is this a CTF game? (def=no)  DESUPPORTED.
-; HarvesterTruce = are harvesters immune to enemy fire? (def=no)  DESUPPORTED.
-; MultiEngineer = do you need more than one engineer to take over a building? (def=no)  DESUPPORTED.
-; AlliesAllowed = are allies allowed in this game? (def=no)
-; ShortGame = is a player eliminated when his last building is destroyed? (def=yes)
-; FogOfWar = is there fog of war in this game? (def=no)
-; MCVRedploys = can the player redeploy the MCV? (def=yes)
-; AllyChangeAllowed = can alliances be changed mid-game? (def=yes)
+; MinUnitCount=minumum number of starting units in a game. (def=1)
+; UnitCount=the default starting units. (def=10)
+; MaxUnitCount=maximum number of starting units. (def=20)
+; TechLevel=maximum tech level achievable in a game. (def=10)
+; GameSpeed=starting game speed. For some wacky reason, 0=fastest, 6=slowest. (def=0)
+; AIDifficulty=starting AI difficulty. (def=1)  (0=easy, 1=normal, 2=hard)
+; AIPlayers=starting number of AI players.  Always at least 1 for skirmish.  (def=0)
+; BridgeDestruction=can bridges be destroyed? (def=true)
+; ShadowGrow=deos the shroud regrow? (def=no)  DESUPPORTED.
+; Shroud=is there a shroud on the map? (def=yes)  NOT YET SUPPORTED.
+; Bases=can you build buildings or is this just a unit-to-unit slugfest. (def=yes)  DESUPPORTED.
+; TiberiumGrows=does ore/tiberium/whatever regenerate? (def=yes)
+; Crates=do crates appear in the game? (def=yes)
+; CaptureTheFlag=is this a CTF game? (def=no)  DESUPPORTED.
+; HarvesterTruce=are harvesters immune to enemy fire? (def=no)  DESUPPORTED.
+; MultiEngineer=do you need more than one engineer to take over a building? (def=no)  DESUPPORTED.
+; AlliesAllowed=are allies allowed in this game? (def=no)
+; ShortGame=is a player eliminated when his last building is destroyed? (def=yes)
+; FogOfWar=is there fog of war in this game? (def=no)
+; MCVRedploys=can the player redeploy the MCV? (def=yes)
+; AllyChangeAllowed=can alliances be changed mid-game? (def=yes)
 
 [MultiplayerDialogSettings]
 MinMoney=5000
@@ -3430,17 +3436,17 @@ SellBack=2              ; allowed to sell buildings
 ; by that country. This applies only to multiplayer games and skirmish mode. In
 ; normal game play, all values are "1.0".
 
-; Airspeed = multiplier to speed for all air units [larger means faster] (def=1.0)
-; Armor = multiplier to armor strength for all units and buildings [larger means stronger] (def=1.0)
-; Cost = multiplier to cost for all units and buildings [larger means costlier] (def=1.0)
-; Firepower = multiplier to firepower for all weapons [larger means more damage] (def=1.0)
-; Groundspeed = multiplier to speed for all ground units [larger means faster] (def=1.0)
-; ROF = multiplier to Rate Of Fire for all weapons [larger means slower ROF] (def=1.0)
-; BuildTime = multiplier to general object build time [larger means longer to build] (def=1.0)
-; Color = color to use when displaying objects owned by this country [see color schemes]
-; Multiplay = This house used as placeholder for multiplay house (def=no)?
-; WallOwner = Will this house own walls that are placed near its buildings (def=yes)?
-; SmartAI = Does it presume to have the smart AI logic already enabled (def=no)?
+; Airspeed=multiplier to speed for all air units [larger means faster] (def=1.0)
+; Armor=multiplier to armor strength for all units and buildings [larger means stronger] (def=1.0)
+; Cost=multiplier to cost for all units and buildings [larger means costlier] (def=1.0)
+; Firepower=multiplier to firepower for all weapons [larger means more damage] (def=1.0)
+; Groundspeed=multiplier to speed for all ground units [larger means faster] (def=1.0)
+; ROF=multiplier to Rate Of Fire for all weapons [larger means slower ROF] (def=1.0)
+; BuildTime=multiplier to general object build time [larger means longer to build] (def=1.0)
+; Color=color to use when displaying objects owned by this country [see color schemes]
+; Multiplay=This house used as placeholder for multiplay house (def=no)?
+; WallOwner=Will this house own walls that are placed near its buildings (def=yes)?
+; SmartAI=Does it presume to have the smart AI logic already enabled (def=no)?
 
 ;Enough of theirs.  Here's the real stuff.  VeteranXXX can be used to make all units
 ;of that type start as veterans.  Please stay clear on the meaning of Infantry, Unit, and Aircraft.
@@ -3703,18 +3709,18 @@ TopYellow=16,32,0;10000,100000,00000		13
 ; individual settings. Thus the computer may be playing at 'difficult' level while the
 ; player may be playing at 'easy' level.
 
-; Airspeed = multiplier to speed for all air units (def=1.0)
-; Armor = multiplier to armor strength for all units and buildings (def=1.0)
-; Cost = multiplier to cost for all units and buildings (def=1.0)
-; Firepower = multiplier to firepower for all weapons (def=1.0)
-; Groundspeed = multiplier to speed for all ground units (def=1.0)
-; ROF = multiplier to Rate Of Fire for all weapons [larger means slower ROF] (def=1.0)
-; BuildSlowdown = Should the computer build slower than the player (def=no)?
+; Airspeed=multiplier to speed for all air units (def=1.0)
+; Armor=multiplier to armor strength for all units and buildings (def=1.0)
+; Cost=multiplier to cost for all units and buildings (def=1.0)
+; Firepower=multiplier to firepower for all weapons (def=1.0)
+; Groundspeed=multiplier to speed for all ground units (def=1.0)
+; ROF=multiplier to Rate Of Fire for all weapons [larger means slower ROF] (def=1.0)
+; BuildSlowdown=Should the computer build slower than the player (def=no)?
 ;  <<< affects the computer player, not the human player >>>
-;    ContentScan = Should the contents of a transport be considered when picking best target (def=no)?
-;    RepairDelay = average delay (minutes) between initiating building repair
-;    BuildDelay = average delay (minutes) between initiating construction
-;    DestroyWalls = Allow scanning for nearby enemy walls and destroy them (def=yes)?
+;    ContentScan=Should the contents of a transport be considered when picking best target (def=no)?
+;    RepairDelay=average delay (minutes) between initiating building repair
+;    BuildDelay=average delay (minutes) between initiating construction
+;    DestroyWalls=Allow scanning for nearby enemy walls and destroy them (def=yes)?
 
 [Easy]
 Groundspeed=1.0
@@ -3757,122 +3763,122 @@ DestroyWalls=no
 ; ******* Unit Statistics *******
 ; Specifies the characteristics of the various game objects.
 
-; AllowedToStartInMultiplayer = Can the unit be allocated to a player when starting a multiplayer game (def=yes)
-; Ammo = number of rounds carried between reloads [-1 means unlimited] (def=-1)
-; Armor = the armor type of this object [none,wood,light,heavy,concrete] (def=none);more types added in RA2
-; BuildLimit = arbitrary maximum allowed to build [per house] (def=-1 -- no restriction)
-; Cloakable = Is it equipped with a cloaking device (def=no)?
-; Cost = cost to build object (in credits)
-; Category = category of object [used by AI systems -- "Soldier", "Civilian", "VIP", "Ship",
+; AllowedToStartInMultiplayer=Can the unit be allocated to a player when starting a multiplayer game (def=yes)
+; Ammo=number of rounds carried between reloads [-1 means unlimited] (def=-1)
+; Armor=the armor type of this object [none,wood,light,heavy,concrete] (def=none);more types added in RA2
+; BuildLimit=arbitrary maximum allowed to build [per house] (def=-1 -- no restriction)
+; Cloakable=Is it equipped with a cloaking device (def=no)?
+; Cost=cost to build object (in credits)
+; Category=category of object [used by AI systems -- "Soldier", "Civilian", "VIP", "Ship",
 ;            "Recon", "AFV", "IFV", "LRFS", "Support", "Transport", "AirPower", "AirLift"]
-; CloakStop = Does the unit cloak when stopped moving (def=no)?
-; Crewed = Does it contain a crew that can escape [never infantry] (def=no)?
-; Gunner = Does it change capabilites based on a gunner that has been added. (def=no)
-; CrushSound = sound to play if this object type is crushed (def=none)
-; DeployFire = This unit can fire when deployed. (def=no)
-; DeployFireWeapon = Index of weapon to fire while deployed.  0 or 1.  (def=1)
-; DeployTime = time, in minutes, to deploy or undeploy [if this object can do so]
-; DamageReducesReadiness = Yes if damage to the unit reduces its ammo (because the ammo explodes or becomes detargeted, or whatever) (def=no)
-; Disableable = Can this object be disabled by special multiplay option (def=yes)?
-; DistributedFire = whether the unit continually retargets nearby units and fires at all of them (def=no)
-; DoubleOwned = Can be built/owned by all countries in a multiplayer game (def=no)?
-; EmptyReload = Frames before first reload occurs when unit is empty. -1 means use standard reload time. (def=-1)
-; Explodes = Does it explode violently when destroyed [i.e., does it do collateral damage] (def=no)?
-; Explosion = the explosion to use when it blows up [doesn't apply to infantry] (def=none)
-; FireAngle = pitch of projectile launch and barrel [0 = horizontal, 64 = vertical] (def=50)
-; Gate = Is this building a gate? (def=no)
-; GateCloseDelay = time, in minutes, to delay before closing a gate after it has opened.
-; GuardRange = distance to scan for enemies to attack (def=use weapon range)
-; Image = name of graphic data to use for this object (def=same as object identifier)
-; Immune = Is this object immune to damage
-; ImmuneToPsionics = Is the unit immune to psionics (def=yes for buildings, no for others)?
-; ImmuneToRadiation = Is the unit immune to radiation (def=no)?
-; ImmuneToVeins = Is it immune to vein creature attacks (def=no)?
-; InitialAmmo = number of rounds the unit starts with. -1 means it starts full. (def=-1)
-; Invisible = Is completely and always invisible to enemy (def=no)?
-; Insignificant = Will this object not be announed when destroyed (def=no)?
-; LegalTarget = Is this allowed to be a combat target (def=yes)?
-; Name = specifies the given name (displayed) for the object
-; Nominal = Always use the given name rather than generic "enemy object" (def=no)?
-; OmniFire = Doesn't ever have to rotate to fire. (def=no)
-; OpportunityFire = Can fire at targets while performing other actions, like moving. (def=no).
-; Owner = who can build this [GDI or Nod] (def=none)
-; PipScale = what to base pip display on [Passengers, Tiberium, Ammo, Power] (def=none)
-; PipWrap = how many pips to draw before wrapping (def=none)
-; Points = point value for scoring purposes (def=0)
-; Prerequisite = list of buildings needed before this can be manufactured (def=no requirement)
-; PreventAttackMove = Does this unit know how to do attack-move? (def=<yes, if it has a weapon>)
+; CloakStop=Does the unit cloak when stopped moving (def=no)?
+; Crewed=Does it contain a crew that can escape [never infantry] (def=no)?
+; Gunner=Does it change capabilites based on a gunner that has been added. (def=no)
+; CrushSound=sound to play if this object type is crushed (def=none)
+; DeployFire=This unit can fire when deployed. (def=no)
+; DeployFireWeapon=Index of weapon to fire while deployed.  0 or 1.  (def=1)
+; DeployTime=time, in minutes, to deploy or undeploy [if this object can do so]
+; DamageReducesReadiness=Yes if damage to the unit reduces its ammo (because the ammo explodes or becomes detargeted, or whatever) (def=no)
+; Disableable=Can this object be disabled by special multiplay option (def=yes)?
+; DistributedFire=whether the unit continually retargets nearby units and fires at all of them (def=no)
+; DoubleOwned=Can be built/owned by all countries in a multiplayer game (def=no)?
+; EmptyReload=Frames before first reload occurs when unit is empty. -1 means use standard reload time. (def=-1)
+; Explodes=Does it explode violently when destroyed [i.e., does it do collateral damage] (def=no)?
+; Explosion=the explosion to use when it blows up [doesn't apply to infantry] (def=none)
+; FireAngle=pitch of projectile launch and barrel [0=horizontal, 64=vertical] (def=50)
+; Gate=Is this building a gate? (def=no)
+; GateCloseDelay=time, in minutes, to delay before closing a gate after it has opened.
+; GuardRange=distance to scan for enemies to attack (def=use weapon range)
+; Image=name of graphic data to use for this object (def=same as object identifier)
+; Immune=Is this object immune to damage
+; ImmuneToPsionics=Is the unit immune to psionics (def=yes for buildings, no for others)?
+; ImmuneToRadiation=Is the unit immune to radiation (def=no)?
+; ImmuneToVeins=Is it immune to vein creature attacks (def=no)?
+; InitialAmmo=number of rounds the unit starts with. -1 means it starts full. (def=-1)
+; Invisible=Is completely and always invisible to enemy (def=no)?
+; Insignificant=Will this object not be announed when destroyed (def=no)?
+; LegalTarget=Is this allowed to be a combat target (def=yes)?
+; Name=specifies the given name (displayed) for the object
+; Nominal=Always use the given name rather than generic "enemy object" (def=no)?
+; OmniFire=Doesn't ever have to rotate to fire. (def=no)
+; OpportunityFire=Can fire at targets while performing other actions, like moving. (def=no).
+; Owner=who can build this [GDI or Nod] (def=none)
+; PipScale=what to base pip display on [Passengers, Tiberium, Ammo, Power] (def=none)
+; PipWrap=how many pips to draw before wrapping (def=none)
+; Points=point value for scoring purposes (def=0)
+; Prerequisite=list of buildings needed before this can be manufactured (def=no requirement)
+; PreventAttackMove=Does this unit know how to do attack-move? (def=<yes, if it has a weapon>)
 ;   Can be used to override attack move on units that shouldn't for various reasons.
-; PreventAutoDeploy = Does this unit know how to do auto-deploy? (def=<yes, if the unit support deploying>)
+; PreventAutoDeploy=Does this unit know how to do auto-deploy? (def=<yes, if the unit support deploying>)
 ;	Can be used to override auto deploy on units that deploy.
-; Primary = primary weapon equipped with (def=none)
-; Secondary = secondary weapon equipped with (def=none)
-; ElitePrimary = new primary weapon when at elite veteran status (def=same as primary)
-; EliteSecondary = new secondary weapon when at elite veteran status (def=same as secondary)
-; RadarVisible = Is visible on radar even if insignificant and unowned --gs rewrote to be useful for something
-; ROT = Rate Of Turn for body (if present) and turret (if present) (def=0)
-; ReadinessReductionMultiplier = Used to tweak the amount by which damage reduces readiness. 0 cancels the readiness reduction. (def=0)
-; Reload = time delay between reloads (def=0)
-; ReloadIncrement = amount to add at every ((MaxAmmo / PipWrap) %0) increment. Used to slow reload rate increasingly. (def=0)
-; RadarInvisible = Is it invisible on radar maps (def=no)?
-; RadialFireSegments = If this unit has a radial firing pattern, this determines the number
+; Primary=primary weapon equipped with (def=none)
+; Secondary=secondary weapon equipped with (def=none)
+; ElitePrimary=new primary weapon when at elite veteran status (def=same as primary)
+; EliteSecondary=new secondary weapon when at elite veteran status (def=same as secondary)
+; RadarVisible=Is visible on radar even if insignificant and unowned --gs rewrote to be useful for something
+; ROT=Rate Of Turn for body (if present) and turret (if present) (def=0)
+; ReadinessReductionMultiplier=Used to tweak the amount by which damage reduces readiness. 0 cancels the readiness reduction. (def=0)
+; Reload=time delay between reloads (def=0)
+; ReloadIncrement=amount to add at every ((MaxAmmo / PipWrap) %0) increment. Used to slow reload rate increasingly. (def=0)
+; RadarInvisible=Is it invisible on radar maps (def=no)?
+; RadialFireSegments=If this unit has a radial firing pattern, this determines the number
 ;    of segments. This starts at the unit's left and goes right over 180 degrees.  (def=0)
-; SelfHealing = Does the object heal automatically up to half strength (def=no)?
-; Selectable = Can this object be selected by the player (def=yes)?
-; Sensors = Has sensors to detect nearby cloaked objects (def=no)?
-; Sight = sight range, in cells (def=1)
-; Size = amount of space unit takes up in cargo hold (def=1)
-; SizeLimit = Max size of unit a transport can carry (def=0) (Size is inclusive. Limit 3 holds 3)
-; Storage = the number of 'bails' this building or unit can store (def=0)
-; Strength = strength (hit points) of this object
-; TargetLaser = Does it have a targeting laser (def=no)?
-; Trainable = Can this object become veteran by experience (def=yes, buildings def=no)?
-; Turret = Is it equipped with a turret like superstructure [never infantry] (def=no)?
-; TurretSpins = Does the turret just sit and spin [only if turret equipped] (def=no)?
-; TechLevel = tech level required to build this [-1 means can't build] (def=-1)
-; ToProtect = Should friendly units come to rescue if under attack [computer only] (def=no)?
-; TypeImmune = Immune to damage from same type objects if owned by same side?
-; UndeployDelay = The time it takes before a unit automatically undeploys. (def=-1)
-; VoiceSelect = list of voices when selecting this object (def=none)
-; VoiceMove = list of voices to use when giving object a movement order (def=none)
-; VoiceAttack = list of voices to use when giving object an attack order (def=none)
-; DieSound = list of voices to use when it dies (def=none)
-; VoiceFeedback = list of voices that may give when taking damage (def=none)
-; Locomotor = CLSID of the object handling movement for this object (def=statue)
-; VeteranAbilities = list of veteran abilities to grant (def=none)
-; EliteAbilities = list of elite abilities to grant cumulative with veteran abilities (def=none)
+; SelfHealing=Does the object heal automatically up to half strength (def=no)?
+; Selectable=Can this object be selected by the player (def=yes)?
+; Sensors=Has sensors to detect nearby cloaked objects (def=no)?
+; Sight=sight range, in cells (def=1)
+; Size=amount of space unit takes up in cargo hold (def=1)
+; SizeLimit=Max size of unit a transport can carry (def=0) (Size is inclusive. Limit 3 holds 3)
+; Storage=the number of 'bails' this building or unit can store (def=0)
+; Strength=strength (hit points) of this object
+; TargetLaser=Does it have a targeting laser (def=no)?
+; Trainable=Can this object become veteran by experience (def=yes, buildings def=no)?
+; Turret=Is it equipped with a turret like superstructure [never infantry] (def=no)?
+; TurretSpins=Does the turret just sit and spin [only if turret equipped] (def=no)?
+; TechLevel=tech level required to build this [-1 means can't build] (def=-1)
+; ToProtect=Should friendly units come to rescue if under attack [computer only] (def=no)?
+; TypeImmune=Immune to damage from same type objects if owned by same side?
+; UndeployDelay=The time it takes before a unit automatically undeploys. (def=-1)
+; VoiceSelect=list of voices when selecting this object (def=none)
+; VoiceMove=list of voices to use when giving object a movement order (def=none)
+; VoiceAttack=list of voices to use when giving object an attack order (def=none)
+; DieSound=list of voices to use when it dies (def=none)
+; VoiceFeedback=list of voices that may give when taking damage (def=none)
+; Locomotor=CLSID of the object handling movement for this object (def=statue)
+; VeteranAbilities=list of veteran abilities to grant (def=none)
+; EliteAbilities=list of elite abilities to grant cumulative with veteran abilities (def=none)
 ;     [FASTER,STRONGER,FIREPOWER,SCATTER,ROF,SIGHT,
 ;      CLOAK,TIBERIUM_PROOF,VEIN_PROOF,SELF_HEAL,EXPLODES,
 ;      RADAR_INVISIBLE,SENSORS,FEARLESS,C4,TIBERIUM_HEAL,
 ;      GUARD_AREA,CRUSHER]
-; LeadershipRating = When the AI needs a representative from a team to make a pathfinding or targeting decision it will pick the one with the highest score (def = 5)
+; LeadershipRating=When the AI needs a representative from a team to make a pathfinding or targeting decision it will pick the one with the highest score (def=5)
 ;  <<< applies only to infantry types >>>
-;    Agent = Does it have spy-like abilities (def=no)?
-;    Fearless = Is not prone to fear (def=no)?
-;    VoiceComment = list of idle voices (def=none)
-;    Pip = color of pip when inside a transport [green,yellow,white,red,blue] (def=green)
-;    C4 = Equipped with building sabotage explosives [presumes Infiltrate is true] (def=no)?
-;    Cyborg = Does it require special cyborg death handling (def=no)?
-;    Fraidycat = Is it inherently afraid and will panic easily (def=no)?
-;    TiberiumProof = Is it immune to tiberium and tiberium gas damage (def=no)?
-;    Infiltrate = Can it enter a building like a spy or thief (def=no)?
-;    IsCanine = Should special case dog logic be applied to this?
-;    Civilian = Counts a civilian for evac and kill tracking (def=no)?
-;    FemaleVoice = Uses the civilian female voice (def=no)?
-;    Engineer = Does it behave like an engineer as far as repair and capture go (def=no)?
-;    Disguised = Is it disguised as enemy soldier when seen by enemy (def=no)?
-;    Agent = Does this infantry gather information if it enters an enemy building [like a spy] (def=no)?
-;    Thief = Does it steal money if it infiltrates an enemy building (def=no)?
-;    VehicleThief = Does it steal enemy vehicles when it gets close to one (def=no)?
-;    Deployer = Deploys like NOD artillery from TibSun. (def=no)
+;    Agent=Does it have spy-like abilities (def=no)?
+;    Fearless=Is not prone to fear (def=no)?
+;    VoiceComment=list of idle voices (def=none)
+;    Pip=color of pip when inside a transport [green,yellow,white,red,blue] (def=green)
+;    C4=Equipped with building sabotage explosives [presumes Infiltrate is true] (def=no)?
+;    Cyborg=Does it require special cyborg death handling (def=no)?
+;    Fraidycat=Is it inherently afraid and will panic easily (def=no)?
+;    TiberiumProof=Is it immune to tiberium and tiberium gas damage (def=no)?
+;    Infiltrate=Can it enter a building like a spy or thief (def=no)?
+;    IsCanine=Should special case dog logic be applied to this?
+;    Civilian=Counts a civilian for evac and kill tracking (def=no)?
+;    FemaleVoice=Uses the civilian female voice (def=no)?
+;    Engineer=Does it behave like an engineer as far as repair and capture go (def=no)?
+;    Disguised=Is it disguised as enemy soldier when seen by enemy (def=no)?
+;    Agent=Does this infantry gather information if it enters an enemy building [like a spy] (def=no)?
+;    Thief=Does it steal money if it infiltrates an enemy building (def=no)?
+;    VehicleThief=Does it steal enemy vehicles when it gets close to one (def=no)?
+;    Deployer=Deploys like NOD artillery from TibSun. (def=no)
 ;  <<< applies only to moving units (not buildings) >>>
-;    MoveToShroud = Allowed to move into a shrouded cell (def=yes, aircraft def=no)?
-;    Dock = preferred docking building [e.g., harvester -> refinery, helicopter -> helipad] (def=none)
-;    TiberiumHeal = Does it heal slowly when in Tiberium field (def=no)?
-;    Passengers = number of passengers it may carry (def=0)
-;    Speed = speed of this object [n/a for buildings] (def=0)
-;    ManualReload = Must this object reload by coordinating with reloader building (def=no)?
-;    WalkRate = walking animation rate [larger means slower] (def=1)
+;    MoveToShroud=Allowed to move into a shrouded cell (def=yes, aircraft def=no)?
+;    Dock=preferred docking building [e.g., harvester -> refinery, helicopter -> helipad] (def=none)
+;    TiberiumHeal=Does it heal slowly when in Tiberium field (def=no)?
+;    Passengers=number of passengers it may carry (def=0)
+;    Speed=speed of this object [n/a for buildings] (def=0)
+;    ManualReload=Must this object reload by coordinating with reloader building (def=no)?
+;    WalkRate=walking animation rate [larger means slower] (def=1)
 ;    IsSelectableCombatant=Does this unit get selected by the select all combatants key? (def=no)
 ;  <<< applies only to turret changers >>>
 ;    TurretCount=the number of turrets the unit has (def=0)
@@ -3880,63 +3886,63 @@ DestroyWalls=no
 ;    YTurretIndex=the number of the weapon for this turret (as indicated by the WeaponX parameter), where Y is the name of swapping factor for the turret (def=none)
 ;    HasTurretTooltips=whether this unit multiplexes tooltips based on its current turret. (def=no)
 ;  <<< applies only to terrestrial driving vehicle types >>>
-;    CrateGoodie = Can it appear out of a crate in multiplay (def=no)?
-;    Crushable = Can it be crushed by a heavy tracked vehicle (def=no)?
-;    Crusher = Is this vehicle able to crush infantry (def=no)?
-;    MovingFire = The vehicle does not need to stop before it can fire (def=yes)?
-;    DeployToFire = The vehicle must deploy before it can fire (def=no)?
-;    Harvester = Does the special Tiberium harvesting rules apply (def=no)?
-;    Weeder = Does the special weed-harvesting rules apply (def=no)?
-;    Deployer = Does it deploy before being able to operate (def=no)? OBSOLETE
-;    IsTilter = Does this unit tilt on slopes (def=yes)?
-;    CarriesCrate = Might this unit drop a crate when it is destroyed (def=no)?
+;    CrateGoodie=Can it appear out of a crate in multiplay (def=no)?
+;    Crushable=Can it be crushed by a heavy tracked vehicle (def=no)?
+;    Crusher=Is this vehicle able to crush infantry (def=no)?
+;    MovingFire=The vehicle does not need to stop before it can fire (def=yes)?
+;    DeployToFire=The vehicle must deploy before it can fire (def=no)?
+;    Harvester=Does the special Tiberium harvesting rules apply (def=no)?
+;    Weeder=Does the special weed-harvesting rules apply (def=no)?
+;    Deployer=Does it deploy before being able to operate (def=no)? OBSOLETE
+;    IsTilter=Does this unit tilt on slopes (def=yes)?
+;    CarriesCrate=Might this unit drop a crate when it is destroyed (def=no)?
 ;  <<< applies only to aircraft >>>
-;    Carryall = Can it tote vehicles around (def=no)?
-;    Landable = Can this aircraft land on the map (def=no)?
-;    PitchSpeed = Throttle setting at which aircraft pitch forward (def=.25);
-;    PitchAngle = Amount that non-FixedWing aircraft pitch forward in degrees (def=20.0);
-;    RollAngle = Amount that the aircraft rolls when turning (def=30.0)
+;    Carryall=Can it tote vehicles around (def=no)?
+;    Landable=Can this aircraft land on the map (def=no)?
+;    PitchSpeed=Throttle setting at which aircraft pitch forward (def=.25);
+;    PitchAngle=Amount that non-FixedWing aircraft pitch forward in degrees (def=20.0);
+;    RollAngle=Amount that the aircraft rolls when turning (def=30.0)
 ;  <<< applies only to building types >>>
-;    Adjacent = distance allowed to place from other buildings (def=1)
-;    BaseNormal = Considered for building adjacency checks (def=yes)? ;HEY!  Use this, not the phantom IsBase
-;    Barrel = Use barrel explosion logic when it is destroyed (def=no)?
-;    Bib = Does the building have a bib built in (def=no)?
-;    Capturable = Can this building be infiltrated by a spy/engineer (def=no)?
-;    DockUnload = When a unit docks with this building should it unload (def=no)?
-;    Factory = type of object to build [InfantryType, AircraftType, UnitType, BuildingType, VesselType] (def=none)
-;    Fake = Is this a fake structure (def=no)?
-;    FreeUnit = free unit to give this building [typically harvester with refinery] (def=none)
-;    Power = power output [positive for output, negative for drain] (def=0)
-;    Powered = Does it require power to function (def=no)?
-;    Radar = Does this building give radar to owning player (def=no)?
-;    Repairable = Can it be repaired (def=yes)?
+;    Adjacent=distance allowed to place from other buildings (def=1)
+;    BaseNormal=Considered for building adjacency checks (def=yes)? ;HEY!  Use this, not the phantom IsBase
+;    Barrel=Use barrel explosion logic when it is destroyed (def=no)?
+;    Bib=Does the building have a bib built in (def=no)?
+;    Capturable=Can this building be infiltrated by a spy/engineer (def=no)?
+;    DockUnload=When a unit docks with this building should it unload (def=no)?
+;    Factory=type of object to build [InfantryType, AircraftType, UnitType, BuildingType, VesselType] (def=none)
+;    Fake=Is this a fake structure (def=no)?
+;    FreeUnit=free unit to give this building [typically harvester with refinery] (def=none)
+;    Power=power output [positive for output, negative for drain] (def=0)
+;    Powered=Does it require power to function (def=no)?
+;    Radar=Does this building give radar to owning player (def=no)?
+;    Repairable=Can it be repaired (def=yes)?
 ;		RevealToAll=yes Means that when built or captured, a radar event is generated (def=no)
-;    UnitReload = Does this building reload units if they dock with it (def=no)?
-;    UnitRepair = Does this building repair units if they dock with it (def=no)?
-;    Unsellable = Cannot sell this building (even if it can be built)?
-;    Wall = Is this a wall type structure [special rules apply] (def=no)?
-;    WaterBound = Is this building placed on water only (def=no)?
-;    Upgrades = Is the number of power-ups/upgrades that can be applied to this building (def=0)
-;    ShipYard = This building is a ship yard or sub pen
-;    SAM = This building is a SAM launcher
-;    ConstructionYard = This building is a construction yard
-;    Refinery = This building is a tiberium/ore refinery
-;    WeaponsFactory = This building is a weapons factory
-;    CloakGenerator = Does this building cloak objects around it?
-;    LaserFencePost = This building is a laser fence post and obeys the rules for a building of this type.
-;    LightIntensity = This building radiates this amount of light (def = 0).
-;    LightVisibility= The distance (in leptons) that this light is visible from (def=5000).
-;    LightRedTint   = The red tint of this buildings light (def=1.0)
-;    LightGreenTint = The green tint of this buildings light (def=1.0)
-;    LightBlueTint  = The blue tint of this buildings light (def=1.0)
-;    InvisibleInGame= Building cannot be seen on selected in the game, only in the editor. (def=no)
-;    PowersUpBuilding = Building that can be upgraded by attaching this building to it
-;    PowersUpToLevel = Amount of upgrade provided by this attachment. -1=incremental upgrade. Positive number is specific upgrade.
-;    Hospital = Can this building heal infantry (def = no) ?
-;    Armory = Is this building an armory
-;    PlaceAnywhere = Can this building ignore normal placement rules? Only use this for non-player placed buildings (def = no).
-;    Weeder = Is this a weed collection facility (def=no)?
-;    TogglePower = [override] Can be turned on/off under player control or affected by low power (def=yes)?
+;    UnitReload=Does this building reload units if they dock with it (def=no)?
+;    UnitRepair=Does this building repair units if they dock with it (def=no)?
+;    Unsellable=Cannot sell this building (even if it can be built)?
+;    Wall=Is this a wall type structure [special rules apply] (def=no)?
+;    WaterBound=Is this building placed on water only (def=no)?
+;    Upgrades=Is the number of power-ups/upgrades that can be applied to this building (def=0)
+;    ShipYard=This building is a ship yard or sub pen
+;    SAM=This building is a SAM launcher
+;    ConstructionYard=This building is a construction yard
+;    Refinery=This building is a tiberium/ore refinery
+;    WeaponsFactory=This building is a weapons factory
+;    CloakGenerator=Does this building cloak objects around it?
+;    LaserFencePost=This building is a laser fence post and obeys the rules for a building of this type.
+;    LightIntensity=This building radiates this amount of light (def=0).
+;    LightVisibility=The distance (in leptons) that this light is visible from (def=5000).
+;    LightRedTint=The red tint of this buildings light (def=1.0)
+;    LightGreenTint=The green tint of this buildings light (def=1.0)
+;    LightBlueTint=The blue tint of this buildings light (def=1.0)
+;    InvisibleInGame=Building cannot be seen on selected in the game, only in the editor. (def=no)
+;    PowersUpBuilding=Building that can be upgraded by attaching this building to it
+;    PowersUpToLevel=Amount of upgrade provided by this attachment. -1=incremental upgrade. Positive number is specific upgrade.
+;    Hospital=Can this building heal infantry (def=no) ?
+;    Armory=Is this building an armory
+;    PlaceAnywhere=Can this building ignore normal placement rules? Only use this for non-player placed buildings (def=no).
+;    Weeder=Is this a weed collection facility (def=no)?
+;    TogglePower=[override] Can be turned on/off under player control or affected by low power (def=yes)?
 ;
 ;	 WST 6/23/99. Below are new zbuffer adjustment for units
 ;	 ZFudgeCliff // fudge for units behind cliffs showing through rocks
@@ -3957,19 +3963,19 @@ DestroyWalls=no
 ;These will control what can shoot what for the last durn time.  Defaults are 0's
 ;This has no impact on anti/not anti air weapons.  Those already work.
 ;NavalTargeting
-;	UNDERWATER_NEVER = 0,			Can't shoot at all at underwater
-;	UNDERWATER_SECONDARY = 1,	Use Second weapon against underwater
-;	UNDERWATER_ONLY = 2,			Can only shoot underwater
-;	ORGANIC_SECONDARY = 3,		Use second Weapon on organic
-;	SEAL_SPECIAL = 4,					Primary on Amphibious and organic, Second on Naval and underwater-not-organic
-;	NAVAL_ALL = 5,						Go ahead and shoot everything with Primary
-; NAVAL_NONE = 6,						Don't even shoot into the water
-; NAVAL_PRIMARY = 7				Able to shoot ground target with secondary weapon, but Naval is the primary target
+;	UNDERWATER_NEVER=0,			Can't shoot at all at underwater
+;	UNDERWATER_SECONDARY=1,	Use Second weapon against underwater
+;	UNDERWATER_ONLY=2,			Can only shoot underwater
+;	ORGANIC_SECONDARY=3,		Use second Weapon on organic
+;	SEAL_SPECIAL=4,					Primary on Amphibious and organic, Second on Naval and underwater-not-organic
+;	NAVAL_ALL=5,						Go ahead and shoot everything with Primary
+; NAVAL_NONE=6,						Don't even shoot into the water
+; NAVAL_PRIMARY=7				Able to shoot ground target with secondary weapon, but Naval is the primary target
 
 ;LandTargeting
-;	LAND_OKAY = 0,						Land is okay
-;	LAND_NOT_OKAY = 1,				Land is OK
-;	LAND_SECONDARY = 2				Can shoot land, but only with secondary weapon
+;	LAND_OKAY=0,						Land is okay
+;	LAND_NOT_OKAY=1,				Land is OK
+;	LAND_SECONDARY=2				Can shoot land, but only with secondary weapon
 ; **************************************************************************
 ; **************************************************************************
 ; **************************** Infantry Types ******************************
@@ -7049,8 +7055,8 @@ VoiceAttack=IFVAttackCommand
 VoiceFeedback=
 DieSound=GenVehicleDie
 MoveSound=IFVMoveStart
-EnterTransportSound= IFVTransform
-LeaveTransportSound= IFVTransform
+EnterTransportSound=IFVTransform
+LeaveTransportSound=IFVTransform
 CrushSound=TankCrush
 MaxDebris=3
 DebrisTypes=TIRE
@@ -7724,8 +7730,8 @@ VoiceAttack=RobotTankAttackCommand
 VoiceFeedback=
 DieSound=RobotTankDie
 MoveSound=RobotTankMoveStart
-ActivateSound= RobotTankOnline
-DeactivateSound= RobotTankOffline
+ActivateSound=RobotTankOnline
+DeactivateSound=RobotTankOffline
 CrushSound=TankCrush
 MaxDebris=2
 SpeedType=Hover
@@ -9075,7 +9081,7 @@ VoiceAttack=ChaosDroneAttackCommand
 VoiceMove=ChaosDroneMove
 VoiceFeedback=
 DieSound=ChaosDroneDie
-MoveSound= ChaosDroneMoveStart
+MoveSound=ChaosDroneMoveStart
 MaxDebris=2
 Locomotor={4A582741-9839-11d1-B709-00A024DDAFD1};<-drive   mech->{55D141B8-DB94-11d1-AC98-006008055BB5}
 ;MovementZone=Normal ;gs FLAW needs to be changed to this when The Flaw is fixed
@@ -9377,7 +9383,7 @@ Size=3
 StupidHunt=yes ;this guy can't handle a hunt command, so he should just run towards the player
 Trainable=yes
 DeploysInto=YAREFN
-DeployFacing=0;0 = N, 7 = NW
+DeployFacing=0;0=N, 7=NW
 Enslaves=SLAV;gs The Refinery does not get an Enslaves listing because the Slave object will get passed from unit to building upon deploy
 SlavesNumber=5
 SlaveRegenRate=500 ;225
@@ -12878,8 +12884,8 @@ ThreatPosed=0 ; This value MUST be 0 for all building addons
 DamageParticleSystems=SparkSys,SmallGreySSys,BigGreySmokeSys
 DamageSmokeOffset=395,750,410
 AIBuildThis=yes
-;ExitCoord = 1280,256,0
-;ExitCoord = 610,188,0 ;above - 670 and 68
+;ExitCoord=1280,256,0
+;ExitCoord=610,188,0 ;above - 670 and 68
 ;ExitCoord=384,96,0
 ExitCoord=512,256,0 ;gs 96 isn't the center of a cell.  This causes pop when the Force Track grabs hold.
 Spyable=yes
@@ -13580,7 +13586,7 @@ ImmuneToPsionics=yes ; defaults to yes for buildings, no for others
 BaseNormal=no
 UndeploysInto=SMIN
 ClickRepairable=no
-DeployFacing=0;0 = N, 7 = NW
+DeployFacing=0;0=N, 7=NW
 ResourceGatherer=yes;gs for the AI to handle the slave miner, it has to understand what makes money
 ResourceDestination=yes
 VoiceSelect=SlaveMinerSelect
@@ -14187,7 +14193,7 @@ TurretAnimZAdjust=-140
 FireAngle=0	; hopefully horizontal
 Capturable=yes
 NeedsEngineer=yes
-CaptureEvaEvent= EVA_RepairFacilityCaptured  ;Eva (and therefore 3way split) voice to use when captured
+CaptureEvaEvent=EVA_RepairFacilityCaptured  ;Eva (and therefore 3way split) voice to use when captured
 Unsellable=yes
 NumberOfDocks=1
 LeaveRubble=yes
@@ -14212,7 +14218,7 @@ MinDebris=5
 DebrisAnims=Dbris1sm,Dbris1lg,Dbris4sm,Dbris5sm,Dbris4lg,Dbris7sm,Dbris8sm,Dbris5lg,Dbris4lg
 DamageParticleSystems=SmallGreySSys,BigGreySmokeSys
 Capturable=yes
-CaptureEvaEvent= EVA_AirfieldCaptured  ;Eva (and therefore 3way split) voice to use when captured
+CaptureEvaEvent=EVA_AirfieldCaptured  ;Eva (and therefore 3way split) voice to use when captured
 NeedsEngineer=yes
 Unsellable=yes
 Ammo=5
@@ -14236,7 +14242,7 @@ MaxDebris=8
 MinDebris=4
 ;DamageParticleSystems=SmallGreySSys,BigGreySmokeSys
 Capturable=yes
-CaptureEvaEvent= EVA_OilRefineryCaptured  ;Eva (and therefore 3way split) voice to use when captured
+CaptureEvaEvent=EVA_OilRefineryCaptured  ;Eva (and therefore 3way split) voice to use when captured
 NeedsEngineer=yes
 Unsellable=yes
 Explodes=yes
@@ -14264,7 +14270,7 @@ MinDebris=5
 DebrisAnims=Dbris1sm,Dbris1lg,Dbris4sm,Dbris5sm,Dbris4lg,Dbris7sm,Dbris8sm,Dbris5lg,Dbris4lg
 DamageParticleSystems=SmallGreySSys,BigGreySmokeSys
 Capturable=yes
-CaptureEvaEvent=  EVA_TechBuildingCaptured ;Eva (and therefore 3way split) voice to use when captured
+CaptureEvaEvent=EVA_TechBuildingCaptured ;Eva (and therefore 3way split) voice to use when captured
 NeedsEngineer=yes
 Unsellable=yes
 Ammo=5
@@ -14288,7 +14294,7 @@ Armor=concrete
 MaxDebris=8
 MinDebris=4
 Capturable=yes
-CaptureEvaEvent=  EVA_MachineShopCaptured ;Eva (and therefore 3way split) voice to use when captured
+CaptureEvaEvent=EVA_MachineShopCaptured ;Eva (and therefore 3way split) voice to use when captured
 NeedsEngineer=yes
 Unsellable=yes
 Explosion=TWLT070,S_BANG48,S_BRNL58,S_CLSN58,S_TUMU60
@@ -14314,7 +14320,7 @@ MaxDebris=6
 DebrisAnims=Dbris3sm,Dbris4lg,Dbris4sm,Dbris6sm,Dbris7lg,Dbris7sm,Dbris8sm,Dbris9lg,Dbris10lg,Dbris10sm
 DamageParticleSystems=SmallGreySSys,BigGreySmokeSys
 Capturable=yes
-CaptureEvaEvent= EVA_HospitalCaptured  ;Eva (and therefore 3way split) voice to use when captured
+CaptureEvaEvent=EVA_HospitalCaptured  ;Eva (and therefore 3way split) voice to use when captured
 NeedsEngineer=yes
 Unsellable=yes
 LeaveRubble=yes
@@ -14338,7 +14344,7 @@ MaxDebris=6
 DebrisAnims=Dbris3sm,Dbris4lg,Dbris4sm,Dbris6sm,Dbris7lg,Dbris7sm,Dbris8sm,Dbris9lg,Dbris10lg,Dbris10sm
 DamageParticleSystems=SmallGreySSys,BigGreySmokeSys
 Capturable=yes
-CaptureEvaEvent= EVA_HospitalCaptured  ;Eva (and therefore 3way split) voice to use when captured
+CaptureEvaEvent=EVA_HospitalCaptured  ;Eva (and therefore 3way split) voice to use when captured
 NeedsEngineer=yes
 Unsellable=yes
 LeaveRubble=yes
@@ -14363,7 +14369,7 @@ MaxDebris=8
 MinDebris=4
 ;DamageParticleSystems=SmallGreySSys,BigGreySmokeSys
 Capturable=yes
-CaptureEvaEvent= EVA_SecretLabCaptured  ;Eva (and therefore 3way split) voice to use when captured
+CaptureEvaEvent=EVA_SecretLabCaptured  ;Eva (and therefore 3way split) voice to use when captured
 NeedsEngineer=yes
 Unsellable=yes
 WorkingSound=OilDerrickLoop
@@ -14372,7 +14378,7 @@ LeaveRubble=yes
 ;This will probably be overridden for use in specific maps. Note that only one object can be given by the secret lab, if more than one is specified, only one of them will actually take effect
 ;SecretInfantry
 ;SecretUnit=
-:SecretBuilding=
+;SecretBuilding=
 SecretLab=yes
 RadarVisible=yes;gs put on radar even if insignificant and unowned (insignificant and owned is a UC building)
 
@@ -17736,7 +17742,7 @@ MaxDebris=1
 LightVisibility=4000
 LightIntensity=0.01
 LightRedTint=0.01
-LightGreenTint=0,01
+LightGreenTint=0.01
 LightBlueTint=0.7
 ThreatPosed=0	; This value MUST be 0 for all building addons
 DamageParticleSystems=SparkSys,LGSparkSys
@@ -17935,7 +17941,7 @@ Explosion=TWLT070,S_BANG48,S_BRNL58,S_CLSN58,S_TUMU60
 LightVisibility=4000
 LightIntensity=0.01
 LightRedTint=0.01
-LightGreenTint=0,01
+LightGreenTint=0.01
 LightBlueTint=0.7
 DamageParticleSystems=SparkSys,LGSparkSys
 Powered=true
@@ -22733,27 +22739,27 @@ BaseNormal=no ;psst....IsBase isn't a Rules flag
 ; The weapons specified here are attached to the various combat
 ; units and buildings.
 
-; Anim = animation to display as a firing effect [use 8 for directional variation]
-; AreaFire = indicates that the weapon fires at the current cell and does damage in a radius (def=no). Warning: This only works for secondary weapons right now.
-; Bright = Does this weapons bullet cause a lighting effect when it impacts (def=no)? If set, this will override the warheads 'Bright' flag.
-; Burst = number of rapid succession shots from this weapon (def=1)
-; Camera = Reveals area around firer (def=no)?
-; Charges = SJM: I have disabled this system.  Use IsAnimDelayedFire in ART.INI instead.  Does it have charge-up-before-firing logic (def=no)?
-; Damage = the amount of damage (unattenuated) dealt with every bullet
-; Floater = floats like a frizbee
-; IonSensitive = Shuts down during an ion storm (def=no)?
-; Lobber = does the projectile fly to target in a high arc (def=no)?
-; MinimumRange = minimum range to target (def=0)
-; Projectile = projectile characteristic to use
-; RadLevel = the radiation level left by the weapon. (def=0)
-; Range = maximum cell range
-; ROF = delay between shots [15 = 1 second at middle speed setting]
-; Report = List of sounds to random play when firing
-; Speed = speed of projectile to target (100 is maximum)
-; Supress = Should nearby friendly buildings be scanned for and if found, discourage firing on target (def=no)?
-; TurboBoost = Should the weapon get a boosted speed bonus when firing upon aircraft?
-; UseFireParticles = Should the weapon spawn a flame particle system? (def = no)
-; Warhead = warhead to attach to projectile
+; Anim=animation to display as a firing effect [use 8 for directional variation]
+; AreaFire=indicates that the weapon fires at the current cell and does damage in a radius (def=no). Warning: This only works for secondary weapons right now.
+; Bright=Does this weapons bullet cause a lighting effect when it impacts (def=no)? If set, this will override the warheads 'Bright' flag.
+; Burst=number of rapid succession shots from this weapon (def=1)
+; Camera=Reveals area around firer (def=no)?
+; Charges=SJM: I have disabled this system.  Use IsAnimDelayedFire in ART.INI instead.  Does it have charge-up-before-firing logic (def=no)?
+; Damage=the amount of damage (unattenuated) dealt with every bullet
+; Floater=floats like a frizbee
+; IonSensitive=Shuts down during an ion storm (def=no)?
+; Lobber=does the projectile fly to target in a high arc (def=no)?
+; MinimumRange=minimum range to target (def=0)
+; Projectile=projectile characteristic to use
+; RadLevel=the radiation level left by the weapon. (def=0)
+; Range=maximum cell range
+; ROF=delay between shots [15=1 second at middle speed setting]
+; Report=List of sounds to random play when firing
+; Speed=speed of projectile to target (100 is maximum)
+; Supress=Should nearby friendly buildings be scanned for and if found, discourage firing on target (def=no)?
+; TurboBoost=Should the weapon get a boosted speed bonus when firing upon aircraft?
+; UseFireParticles=Should the weapon spawn a flame particle system? (def=no)
+; Warhead=warhead to attach to projectile
 
 [DefaultDeathWeapon]
 Projectile=Invisible
@@ -23034,7 +23040,7 @@ OmniFire=yes
 ;Ghost's Rail Gun
 [LtRail]
 Damage=0			; this should be 0 for railgun shots
-AmbientDamage=150	; use this for the railgun damage field.  Leave damage = 0
+AmbientDamage=150	; use this for the railgun damage field.  Leave damage=0
 ROF=60		; ROF for railgun is tied to the duration (MaxEC) of the railgun particle
 Range=6
 Projectile=InvisibleLow
@@ -23047,7 +23053,7 @@ Report=BIGGGUN1
 
 ;Mammoth Rail Gun
 [MechRailgun]
-AmbientDamage=200	; use this for the railgun damage field.  Leave damage = 0
+AmbientDamage=200	; use this for the railgun damage field.  Leave damage=0
 Damage=0			; this should be 0 for railgun shots
 ROF=60		; ROF for railgun is tied to the duration (MaxEC) of the railgun particle
 Range=8
@@ -23092,7 +23098,7 @@ Speed=100
 Warhead=GattWH
 Report=GattlingGunAttackLoop1
 ;DownReport=GattlingGunDecreaseLoop1
-Burst = 2
+Burst=2
 Anim=MGUN-N,MGUN-NE,MGUN-E,MGUN-SE,MGUN-S,MGUN-SW,MGUN-W,MGUN-NW
 
 ; rapid fire anti-air machine gun
@@ -23105,7 +23111,7 @@ Speed=100
 Warhead=GattWH
 Report=GattlingGunAttackLoop1
 ;DownReport=GattlingGunDecreaseLoop1
-Burst = 2
+Burst=2
 Anim=MGUN-N,MGUN-NE,MGUN-E,MGUN-SE,MGUN-S,MGUN-SW,MGUN-W,MGUN-NW
 
 ; rapid fire anti-ground machine gun
@@ -23119,7 +23125,7 @@ Warhead=SA
 Report=GattlingGunAttackLoop2
 ;DownReport=GattlingGunDecreaseLoop2
 Anim=GUNFIRE
-Burst = 2
+Burst=2
 
 ; rapid fire anti-air machine gun
 [AAGattling2]
@@ -23132,7 +23138,7 @@ Warhead=GattWH
 Report=GattlingGunAttackLoop2
 ;DownReport=GattlingGunDecreaseLoop2
 Anim=GUNFIRE
-Burst = 2
+Burst=2
 
 ; rapid fire anti-ground machine gun
 [AGGattling3]
@@ -23145,7 +23151,7 @@ Warhead=SSA
 Report=GattlingGunAttackLoop3
 ;DownReport=GattlingGunDecreaseLoop3
 Anim=VTMUZZLE
-Burst = 2
+Burst=2
 
 ; rapid fire anti-air machine gun
 [AAGattling3]
@@ -23158,7 +23164,7 @@ Warhead=GattWH
 Report=GattlingGunAttackLoop3
 ;DownReport=GattlingGunDecreaseLoop3
 Anim=VTMUZZLE
-Burst = 2
+Burst=2
 
 
 ; rapid fire anti-air machine gun
@@ -23171,7 +23177,7 @@ Speed=100
 Warhead=GattWH
 Report=GattlingGunAttackLoop1
 ;DownReport=GattlingGunDecreaseLoop1
-Burst = 2
+Burst=2
 Anim=MGUN-N,MGUN-NE,MGUN-E,MGUN-SE,MGUN-S,MGUN-SW,MGUN-W,MGUN-NW
 
 ; rapid fire anti-air machine gun
@@ -23185,7 +23191,7 @@ Warhead=GattWH
 Report=GattlingGunAttackLoop2
 ;DownReport=GattlingGunDecreaseLoop2
 Anim=GUNFIRE
-Burst = 2
+Burst=2
 
 ; rapid fire anti-air machine gun
 [AAGattCann3]
@@ -23198,7 +23204,7 @@ Warhead=GattWH
 Report=GattlingGunAttackLoop3
 ;DownReport=GattlingGunDecreaseLoop3
 Anim=VTMUZZLE
-Burst = 2
+Burst=2
 
 ; rapid fire machine gun for the neutral outpost
 [OutpostMachineGun]
@@ -23687,10 +23693,10 @@ Warhead=AirstrikeFlare
 MigAttackCursor=yes;like Tanya's SabotageCursor override
 
 ;Charges=no
-;LaserInnerColor = 255,0,0
-;LaserOuterColor = 127,0,0;0,0,0
-;LaserOuterSpread= 40,80,80;20,40,40
-;LaserDuration = 90;15
+;LaserInnerColor=255,0,0
+;LaserOuterColor=127,0,0;0,0,0
+;LaserOuterSpread=40,80,80;20,40,40
+;LaserDuration=90;15
 Projectile=Invisible;LLine2
 ;IsLaser=true	; this flag tells the game to use the special laser draw effect
 IsLine=true
@@ -24202,10 +24208,10 @@ Range=8
 Speed=100
 Projectile=InvisibleHigh
 Warhead=PrismWarhead
-;LaserInnerColor = 216,0,184
-;LaserOuterColor = 80,0,88
-LaserOuterSpread= 0,0,0
-LaserDuration = 15
+;LaserInnerColor=216,0,184
+;LaserOuterColor=80,0,88
+LaserOuterSpread=0,0,0
+LaserDuration=15
 IsLaser=true	; this flag tells the game to use the special laser draw effect
 IsHouseColor=true
 Report=PrismTowerAttack
@@ -24217,10 +24223,10 @@ Range=8
 Speed=100
 Projectile=InvisibleHigh
 Warhead=PrismWarhead
-;LaserInnerColor = 216,0,184
-;LaserOuterColor = 80,0,88
-LaserOuterSpread= 0,0,0
-LaserDuration = 15
+;LaserInnerColor=216,0,184
+;LaserOuterColor=80,0,88
+LaserOuterSpread=0,0,0
+LaserDuration=15
 IsLaser=true	; this flag tells the game to use the special laser draw effect
 IsHouseColor=true
 Report=PrismTowerAttack
@@ -24233,10 +24239,10 @@ Range=12
 Speed=25
 Projectile=InvisibleHigh
 Warhead=PrismWarhead
-;LaserInnerColor = 216,0,184
-;LaserOuterColor = 80,0,88
-LaserOuterSpread= 0,0,0
-LaserDuration = 15
+;LaserInnerColor=216,0,184
+;LaserOuterColor=80,0,88
+LaserOuterSpread=0,0,0
+LaserDuration=15
 IsLaser=true	; this flag tells the game to use the special laser draw effect
 IsHouseColor=true
 Report=PrismTowerAttack
@@ -24249,10 +24255,10 @@ Range=8
 Speed=100
 Projectile=InvisibleHigh
 Warhead=DummyWarhead
-;LaserInnerColor = 32,48,216
-;LaserOuterColor = 24,24,96
-LaserOuterSpread= 0,0,0
-LaserDuration = 15
+;LaserInnerColor=32,48,216
+;LaserOuterColor=24,24,96
+LaserOuterSpread=0,0,0
+LaserDuration=15
 IsLaser=true	; this flag tells the game to use the special laser draw effect
 IsHouseColor=true
 
@@ -24341,10 +24347,10 @@ Range=10.5
 Speed=100
 Warhead=HE
 Report=PrismTowerAttack
-LaserInnerColor = 255,0,0
-LaserOuterColor = 0,0,0
-LaserOuterSpread= 20,40,40
-LaserDuration = 15
+LaserInnerColor=255,0,0
+LaserOuterColor=0,0,0
+LaserOuterSpread=20,40,40
+LaserDuration=15
 Projectile=LLine
 IsBigLaser=true
 IsLaser=true	; this flag tells the game to use the special laser draw effect
@@ -24359,10 +24365,10 @@ Speed=100
 Warhead=HE
 Report=LASTUR1
 Charges=no
-LaserInnerColor = 255,0,0
-LaserOuterColor = 0,0,0
-LaserOuterSpread= 20,40,40
-LaserDuration = 15
+LaserInnerColor=255,0,0
+LaserOuterColor=0,0,0
+LaserOuterSpread=20,40,40
+LaserDuration=15
 Projectile=LLine2
 IsLaser=true	; this flag tells the game to use the special laser draw effect
 
@@ -24652,8 +24658,8 @@ Report=LaserCosmoAttack
 Warhead=LUNARWH
 Bright=yes
 IsHouseColor=true
-LaserOuterSpread= 0,0,0
-LaserDuration = 15
+LaserOuterSpread=0,0,0
+LaserDuration=15
 IsLaser=true	; this flag tells the game to use the special laser draw effect
 
 [DiskLaser]
@@ -24698,11 +24704,11 @@ Speed=40
 Report=PrismTankAttack
 Warhead=CometWH
 Bright=yes
-;LaserInnerColor = 216,0,184
-;LaserOuterColor = 80,0,88
+;LaserInnerColor=216,0,184
+;LaserOuterColor=80,0,88
 IsHouseColor=true
-LaserOuterSpread= 0,0,0
-LaserDuration = 15
+LaserOuterSpread=0,0,0
+LaserDuration=15
 IsLaser=true	; this flag tells the game to use the special laser draw effect
 
 
@@ -24715,11 +24721,11 @@ Projectile=SmallCometP
 Speed=10
 Warhead=CometWH
 Bright=yes
-;LaserInnerColor = 216,0,184
-;LaserOuterColor = 80,0,88
+;LaserInnerColor=216,0,184
+;LaserOuterColor=80,0,88
 IsHouseColor=true
-LaserOuterSpread= 0,0,0
-LaserDuration = 15
+LaserOuterSpread=0,0,0
+LaserDuration=15
 IsLaser=true	; this flag tells the game to use the special laser draw effect
 
 [TeslaFragment]
@@ -24757,10 +24763,10 @@ Speed=40
 Report=MagnetronMagneShake
 Warhead=MagneShakeWH
 ;Bright=yes
-;LaserInnerColor = 216,0,184
-;LaserOuterColor = 80,0,88
-;LaserOuterSpread= 0,0,0
-;LaserDuration = 15
+;LaserInnerColor=216,0,184
+;LaserOuterColor=80,0,88
+;LaserOuterSpread=0,0,0
+;LaserDuration=15
 ;IsLaser=true	; this flag tells the game to use the special laser draw effect
 IsMagBeam=yes
 
@@ -24830,7 +24836,6 @@ Range=6
 Speed=100
 Projectile=InvisibleMedium
 Warhead=ChronoBeam
-Report=
 IsRadBeam=yes
 Report=ChronoLegionAttack
 
@@ -24968,10 +24973,10 @@ Range=12;8
 Speed=100
 Projectile=InvisibleHigh
 Warhead=PrismWarhead
-LaserInnerColor = 216,0,184
-LaserOuterColor = 80,0,88
-LaserOuterSpread= 0,0,0
-LaserDuration = 15
+LaserInnerColor=216,0,184
+LaserOuterColor=80,0,88
+LaserOuterSpread=0,0,0
+LaserDuration=15
 IsBigLaser=true
 IsLaser=true	; this flag tells the game to use the special laser draw effect
 Report=IFVCowshot
@@ -25011,7 +25016,7 @@ Speed=100
 Warhead=GattWH
 Report=GattlingGunAttackLoop1
 ;DownReport=GattlingGunDecreaseLoop1
-Burst = 2
+Burst=2
 Anim=MGUN-N,MGUN-NE,MGUN-E,MGUN-SE,MGUN-S,MGUN-SW,MGUN-W,MGUN-NW
 
 ; rapid fire anti-air machine gun
@@ -25024,7 +25029,7 @@ Speed=100
 Warhead=GattWH
 Report=GattlingGunAttackLoop1
 ;DownReport=GattlingGunDecreaseLoop1
-Burst = 2
+Burst=2
 Anim=MGUN-N,MGUN-NE,MGUN-E,MGUN-SE,MGUN-S,MGUN-SW,MGUN-W,MGUN-NW
 
 ; rapid fire anti-ground machine gun
@@ -25038,7 +25043,7 @@ Warhead=SA
 Report=GattlingGunAttackLoop2
 ;DownReport=GattlingGunDecreaseLoop2
 Anim=GUNFIRE
-Burst = 2
+Burst=2
 
 ; rapid fire anti-air machine gun
 [AAGattling2E]
@@ -25051,7 +25056,7 @@ Warhead=GattWH
 Report=GattlingGunAttackLoop2
 ;DownReport=GattlingGunDecreaseLoop2
 Anim=GUNFIRE
-Burst = 2
+Burst=2
 
 ; rapid fire anti-ground machine gun
 [AGGattling3E]
@@ -25064,7 +25069,7 @@ Warhead=SSA
 Report=GattlingGunAttackLoop3
 ;DownReport=GattlingGunDecreaseLoop3
 Anim=VTMUZZLE
-Burst = 2
+Burst=2
 
 ; rapid fire anti-air machine gun
 [AAGattling3E]
@@ -25077,7 +25082,7 @@ Warhead=GattWH
 Report=GattlingGunAttackLoop3
 ;DownReport=GattlingGunDecreaseLoop3
 Anim=VTMUZZLE
-Burst = 2
+Burst=2
 
 [M1CarbineE]
 Damage=20
@@ -25165,10 +25170,10 @@ Report=FloatingDiscAttack
 Warhead=DiskWH
 Bright=yes
 ;IsHouseColor=true
-LaserInnerColor = 216,0,184
-LaserOuterColor = 80,0,88
-LaserOuterSpread= 0,0,0
-LaserDuration = 15
+LaserInnerColor=216,0,184
+LaserOuterColor=80,0,88
+LaserOuterSpread=0,0,0
+LaserDuration=15
 ;IsLaser=true	; this flag tells the game to use the special laser draw effect
 DiskLaser=yes; new ring draw laser
 OmniFire=yes
@@ -25305,11 +25310,11 @@ Speed=10
 Report=PrismTankAttack
 Warhead=CometWH
 Bright=yes
-;LaserInnerColor = 216,0,184
-;LaserOuterColor = 80,0,88
+;LaserInnerColor=216,0,184
+;LaserOuterColor=80,0,88
 IsHouseColor=true
-LaserOuterSpread= 0,0,0
-LaserDuration = 15
+LaserOuterSpread=0,0,0
+LaserDuration=15
 IsLaser=true	; this flag tells the game to use the special laser draw effect
 
 [SuperCometFragment]
@@ -25321,11 +25326,11 @@ Speed=10
 Report=
 Warhead=CometWH
 Bright=yes
-;LaserInnerColor = 216,0,184
-;LaserOuterColor = 80,0,88
+;LaserInnerColor=216,0,184
+;LaserOuterColor=80,0,88
 IsHouseColor=true
-LaserOuterSpread= 0,0,0
-LaserDuration = 15
+LaserOuterSpread=0,0,0
+LaserDuration=15
 IsLaser=true	; this flag tells the game to use the special laser draw effect
 
 [MirageGunE]
@@ -25713,36 +25718,36 @@ Report=GIAttackDeployed
 ; to its target. Think of the projectile as the "delivery method" used
 ; to get the warhead to the desired target.
 
-; AA = Can this weapon fire upon flying aircraft (def=no)?
-; AG = Can this weapon fire upon ground objects (def=yes)?
-; AN = Can this weapon fire upon naval objects (def=yes)?
-; AS = Can this weapon fire upon sub-marine objects (def=no)?
-; ASW = Is this an Anti-Submarine-Warfare projectile (def=no)?
-; Acceleration = amount to increase missile speed (def=3)
-; Airburst = Does it try to fly over the target instead of hit it (def=no)?
-; Arcing = Does the bullet travel using an arcing path rather than a straight line? (def=no)
-; Arm = arming delay (def=0)
-; Bouncy = Does it bounce a bit upon impact (def=no)?
-; Cluster = number of explosions attached to projectile [cluster-bomb] (def=1)
-; Color = Color  to use for special remapping projectiles (def = none)
-; CourseLockDuration = How many frames the projectile keep its initial course locked for. (def=0)
-; Degenerates = Does the bullet strength weaken as it travels (def=no)?
-; Dropping = Does it fall from a starting height (def=no)?
-; Level = Does it stay at the same altitude in flight? (Currently also acts as IsTorpedo)
-; Elasticity = "bounciness" of the object [should be 0.0 through 1.0] (def=0.75)
-; Image = image to use during flight
-; Inaccurate = Is it inherently inaccurate (def=no)?
-; Inviso = Is the projectile invisible as it travels (def=no)?
-; Parachuted = Equipped with a parachute for dropping from plane (def=no)?
-; Proximity = Does it blow up when near its target (def=no)?
-; ROT = Rate Of Turn [non zero implies homing] (def=0)
-; Ranged = Can it run out of fuel (def=no)?
-; Scalable = Can its animations be tuned up and down on the fly? (def=no)
-; Shadow = If High, does this bullet need to have a shadow drawn? (def = yes)
-; SubjectToCliffs = Can this bullet be stopped by upward cliffs?  No effect on homing projectiles. (def=no)
-; SubjectToElevation = Can this bullet get a range bonus from height?  No effect on homing projectiles.  (def=no)
-; SubjectToWalls = Can this bullet be stopped by walls?  (def=no)
-; VeryHigh = Does it fly at a very high cruise altitude (def=no)?
+; AA=Can this weapon fire upon flying aircraft (def=no)?
+; AG=Can this weapon fire upon ground objects (def=yes)?
+; AN=Can this weapon fire upon naval objects (def=yes)?
+; AS=Can this weapon fire upon sub-marine objects (def=no)?
+; ASW=Is this an Anti-Submarine-Warfare projectile (def=no)?
+; Acceleration=amount to increase missile speed (def=3)
+; Airburst=Does it try to fly over the target instead of hit it (def=no)?
+; Arcing=Does the bullet travel using an arcing path rather than a straight line? (def=no)
+; Arm=arming delay (def=0)
+; Bouncy=Does it bounce a bit upon impact (def=no)?
+; Cluster=number of explosions attached to projectile [cluster-bomb] (def=1)
+; Color=Color  to use for special remapping projectiles (def=none)
+; CourseLockDuration=How many frames the projectile keep its initial course locked for. (def=0)
+; Degenerates=Does the bullet strength weaken as it travels (def=no)?
+; Dropping=Does it fall from a starting height (def=no)?
+; Level=Does it stay at the same altitude in flight? (Currently also acts as IsTorpedo)
+; Elasticity="bounciness" of the object [should be 0.0 through 1.0] (def=0.75)
+; Image=image to use during flight
+; Inaccurate=Is it inherently inaccurate (def=no)?
+; Inviso=Is the projectile invisible as it travels (def=no)?
+; Parachuted=Equipped with a parachute for dropping from plane (def=no)?
+; Proximity=Does it blow up when near its target (def=no)?
+; ROT=Rate Of Turn [non zero implies homing] (def=0)
+; Ranged=Can it run out of fuel (def=no)?
+; Scalable=Can its animations be tuned up and down on the fly? (def=no)
+; Shadow=If High, does this bullet need to have a shadow drawn? (def=yes)
+; SubjectToCliffs=Can this bullet be stopped by upward cliffs?  No effect on homing projectiles. (def=no)
+; SubjectToElevation=Can this bullet get a range bonus from height?  No effect on homing projectiles.  (def=no)
+; SubjectToWalls=Can this bullet be stopped by walls?  (def=no)
+; VeryHigh=Does it fly at a very high cruise altitude (def=no)?
 
 
 
@@ -26306,10 +26311,10 @@ SubjectToWalls=yes
 ; **************************************************************************
 ; *** Particle Systems ***
 ;
-; HoldsWhat = type of particle (see below) that this system manages (required)
-; Spawns = does this system spawn particles by itself (def = no)
-; SpawnFrames = number of frames to wait before spawning another particle
-; ParticleCap = maximum number of particles that can be in this system
+; HoldsWhat=type of particle (see below) that this system manages (required)
+; Spawns=does this system spawn particles by itself (def=no)
+; SpawnFrames=number of frames to wait before spawning another particle
+; ParticleCap=maximum number of particles that can be in this system
 
 [SmallRailgunSys]
 HoldsWhat=SmallRailgunPart
@@ -26439,17 +26444,17 @@ SpawnSparkPercentage=.2
 ; **************************************************************************
 ; *** Particles ***
 ;
-; Image = Imagelist to use for particle
-; Persistent = Does this particle stick around; should always be yes
-; MaxDC = How many frames go by before this particle damages the things near it? (def = 0)
-; MaxEC = How many frames does this object last (def = 0)
-; Damage = How much damage does it do (def = 0)
-; Warhead = What warhead to use for damage purposes (def = WARHEAD_NONE)
-; StartFrame = what frame of image to start on? (def = 0)
-; NumLoopFrames = how many frames form a single loop? (def = 1)
-; WindEffect = to what degree does the wind affect his particle, 0 = not at all, 5 = a lot (def = 0)
-; Velocity = speed at which particle travels (def = 0.0)
-; Radius = how big is this particle? (used for attract/repel)
+; Image=Imagelist to use for particle
+; Persistent=Does this particle stick around; should always be yes
+; MaxDC=How many frames go by before this particle damages the things near it? (def=0)
+; MaxEC=How many frames does this object last (def=0)
+; Damage=How much damage does it do (def=0)
+; Warhead=What warhead to use for damage purposes (def=WARHEAD_NONE)
+; StartFrame=what frame of image to start on? (def=0)
+; NumLoopFrames=how many frames form a single loop? (def=1)
+; WindEffect=to what degree does the wind affect his particle, 0=not at all, 5=a lot (def=0)
+; Velocity=speed at which particle travels (def=0.0)
+; Radius=how big is this particle? (used for attract/repel)
 ;
 ; BehavesLike, DeleteOnStateLimit, EndStateAI, StateAIAdvance are things that
 ; shouldn't be messed with
@@ -26770,18 +26775,18 @@ ColorSpeed=.13
 ; effect, lacks pinpoint accuracy, and acknowledges the fact that
 ; tanks pose little threat to infantry that take cover.
 
-; Spread = Obsolete.  Kept entries to give benchmark for new spread system
-; Wall = Does this warhead damage concrete walls (def=no)?
-; WallAbsoluteDestroyer = Does this warhead do killing damage to a wall, instead of one wound?  (def=no) ;gs
-; Wood = Does this warhead damage wood walls (def=no)?
-; Fire = Does this produce great heat and thus will melt ice (def=no)?
-; Radiation = Is this a radiation weapon?  Certains units will be immune to this. (def=no)
-; Tiberium = Does this warhead destroy tiberium (def=no)?
-; Sparky = Does this warhead cause residual flames (def=no)?
-; Conventional = Is explosive warhead big enough to cause a splash when it hits water [nukes are too big for this] (def=no)?
-; Rocker = Can this warhead cause nearby units to rock upon impact (def=no)?
-; AnimList = list of animations to play when warhead explodes [listed from lesser to greater damage]
-; Verses = damage value verses various armor types (as percentage of full damage)...
+; Spread=Obsolete.  Kept entries to give benchmark for new spread system
+; Wall=Does this warhead damage concrete walls (def=no)?
+; WallAbsoluteDestroyer=Does this warhead do killing damage to a wall, instead of one wound?  (def=no) ;gs
+; Wood=Does this warhead damage wood walls (def=no)?
+; Fire=Does this produce great heat and thus will melt ice (def=no)?
+; Radiation=Is this a radiation weapon?  Certains units will be immune to this. (def=no)
+; Tiberium=Does this warhead destroy tiberium (def=no)?
+; Sparky=Does this warhead cause residual flames (def=no)?
+; Conventional=Is explosive warhead big enough to cause a splash when it hits water [nukes are too big for this] (def=no)?
+; Rocker=Can this warhead cause nearby units to rock upon impact (def=no)?
+; AnimList=list of animations to play when warhead explodes [listed from lesser to greater damage]
+; Verses=damage value verses various armor types (as percentage of full damage)...
 ;           -vs- None, Flak, Plate //infantry
 ;				Light, Medium, Heavy //units
 ;				Wood, Steel, Concrete //buildings
@@ -26795,23 +26800,23 @@ ColorSpeed=.13
 ; A 1% means no retaliate, no passive aquire
 ; A 2% means no passive aquire
 
-; InfDeath = which infantry death animation to use (def=0)
+; InfDeath=which infantry death animation to use (def=0)
 ;             0=instant die, 1=twirl die, 2=explodes, 3=flying death, 4=burn death, 5=electro
 ; NEW ONES 6=Yuri head explode 7=Nuke Melt
 ; Even Newer 8=Virus explosion 9=Brute transformation
 ; Brand spankin new 10=get smashed into pieces by a brute
-; Deform = % chance that this warhead will damage the ground when it hits. (def=0)
-; DeformThreshhold = damage must exceed this amount before deformation can occur (def=0)
-; Particle = Particle effect to use when explosion occurs (def=none)
-; ProneDamage = Damage modifer for infantry when prone (def=1.0)
-; Bright = Does this warhead normally cause a lighting effect when it goes off (def=no). This is overridden in the case of bullets by the weapon 'Bright' flag.
-; CombatLightSize = % of max size; > 0% means force size of combat light, overriding damage-based value (def=0%)
-; Bullets = Is this weapon a bunch of bullet-like gunfire?  (def=no).
-; CellSpread (def 0)= Replaces Spread and WideDamage.  This is actually how far damage from this warhead can spread
+; Deform=% chance that this warhead will damage the ground when it hits. (def=0)
+; DeformThreshhold=damage must exceed this amount before deformation can occur (def=0)
+; Particle=Particle effect to use when explosion occurs (def=none)
+; ProneDamage=Damage modifer for infantry when prone (def=1.0)
+; Bright=Does this warhead normally cause a lighting effect when it goes off (def=no). This is overridden in the case of bullets by the weapon 'Bright' flag.
+; CombatLightSize=% of max size; > 0% means force size of combat light, overriding damage-based value (def=0%)
+; Bullets=Is this weapon a bunch of bullet-like gunfire?  (def=no).
+; CellSpread (def 0)=Replaces Spread and WideDamage.  This is actually how far damage from this warhead can spread
 ;   0 will explicitly only hurt the target, anything higher will at least search some cells around and compare distance
 ; CellInset (def 0)=Use this to tell autodeploy how much inside CellSpread we need to get before autodeploying.
 ;   This way, the desolater won't just blast as soon as the target is on the very edge -- he'll move in a bit.
-; PercentAtMax (def 1.0)= And this is the percent of damage it does at max range; to control fade linearly
+; PercentAtMax (def 1.0)=And this is the percent of damage it does at max range; to control fade linearly
 
 ; EM Pulse cannon warhead.
 [EMPuls];gs disabled in code
@@ -27774,7 +27779,7 @@ AnimList=TSTIMPCT
 
 [ElectricAssault]
 ElectricAssault=yes
-Verses=0%,0,0%,0%,0%,0%,100%,100%,100%,50%,100%
+Verses=0%,0%,0%,0%,0%,0%,100%,100%,100%,50%,100%
 InfDeath=5
 
 [BombDisarm]
@@ -27939,7 +27944,7 @@ Wall=no
 Verses=100%,100%,100%,75%,50%,50%,100%,100%,100%,100%,100%
 AnimList=XGRYSML1,XGRYSML2,EXPLOSML,XGRYMED1,XGRYMED2,EXPLOMED,EXPLOLRG,TWLT070
 
-[MirageWH]	// Supposed to be a heat ray.
+[MirageWH]; Supposed to be a heat ray.
 Verses=100%,100%,80%,100%,100%,100%,30%,20%,20%,100%,100%	; Needs balancing by designers
 AnimList=IRONFX		; temp, should have flash-o-light
 InfDeath=4			; Burn death
@@ -27995,10 +28000,10 @@ ProneDamage=70%
 ; This section lists all the terrain object types and
 ; specifies their characteristics.
 
-; Immune = Is the terrain immune to combat damage (def=no)?
-; WaterBound = Is the terrain only allowed on the water (def=no)?
-; SpawnsTiberium = Does it spawn growth of Tiberium around it (def=no)?
-; IsFlammable = Can "Forest Fires" spread to and damage this terrain type?
+; Immune=Is the terrain immune to combat damage (def=no)?
+; WaterBound=Is the terrain only allowed on the water (def=no)?
+; SpawnsTiberium=Does it spawn growth of Tiberium around it (def=no)?
+; IsFlammable=Can "Forest Fires" spread to and damage this terrain type?
 
 [BOXES01]
 Name=Boxes
@@ -28580,13 +28585,13 @@ SnowOccupationBits=7
 ; ******* Overlay Objects *******
 ; These are graphic objects that can have an effect on the game.
 
-; Tiberium = Is this tiberium [Tiberium grown and graphic logic applies] (def=no)?
-; Crate = Is this overlay a crate (def=no)?
-; CrateTrigger = Is crate to trigger game events (def=no)?
-; RadarInvisible = Is this overlay not visible on the radar map (def=no)?
-; Explodes = Does it explode violently when destroyed [i.e., does it do collateral damage] (def=no)?
-; LegalTarget = Can it be a legal target for attack (def=no)?
-; ChainReaction = Does it explode and affect adjacent cells (def=no)?
+; Tiberium=Is this tiberium [Tiberium grown and graphic logic applies] (def=no)?
+; Crate=Is this overlay a crate (def=no)?
+; CrateTrigger=Is crate to trigger game events (def=no)?
+; RadarInvisible=Is this overlay not visible on the radar map (def=no)?
+; Explodes=Does it explode violently when destroyed [i.e., does it do collateral damage] (def=no)?
+; LegalTarget=Can it be a legal target for attack (def=no)?
+; ChainReaction=Does it explode and affect adjacent cells (def=no)?
 
 [TIB01]
 Name=Tiberium (Green)
@@ -29608,112 +29613,112 @@ Name=Track NwSe
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS02]
 Name=Track NeSw
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS03]
 Name=Track NS
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS04]
 Name=Track EW
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS05]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS06]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS07]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS08]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS09]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS10]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS11]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS12]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS13]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS14]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS15]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS16]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKTUNNEL01]
 Name=Train Tracks
@@ -29749,7 +29754,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG02]
 Image=LOBRDG02
@@ -29757,7 +29762,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG03]
 Image=LOBRDG03
@@ -29765,7 +29770,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG04]
 Image=LOBRDG04
@@ -29773,7 +29778,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG05]
 Image=LOBRDG05
@@ -29781,7 +29786,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG06]
 Image=LOBRDG06
@@ -29789,7 +29794,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG07]
 Image=LOBRDG07
@@ -29797,7 +29802,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG08]
 Image=LOBRDG08
@@ -29805,7 +29810,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG09]
 Image=LOBRDG09
@@ -29813,7 +29818,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG10]
 Image=LOBRDG10
@@ -29821,7 +29826,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG11]
 Image=LOBRDG11
@@ -29829,7 +29834,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG12]
 Image=LOBRDG12
@@ -29837,7 +29842,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG13]
 Image=LOBRDG13
@@ -29845,7 +29850,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG14]
 Image=LOBRDG14
@@ -29853,7 +29858,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG15]
 Image=LOBRDG15
@@ -29861,7 +29866,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG16]
 Image=LOBRDG16
@@ -29869,7 +29874,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG17]
 Image=LOBRDG17
@@ -29877,7 +29882,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG18]
 Image=LOBRDG18
@@ -29885,7 +29890,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG19]
 Image=LOBRDG19
@@ -29893,7 +29898,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG20]
 Image=LOBRDG20
@@ -29901,7 +29906,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG21]
 Image=LOBRDG21
@@ -29909,7 +29914,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG22]
 Image=LOBRDG22
@@ -29917,7 +29922,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG23]
 Image=LOBRDG23
@@ -29925,7 +29930,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG24]
 Image=LOBRDG24
@@ -29933,7 +29938,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG25]
 Image=LOBRDG25
@@ -29941,7 +29946,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG26]
 Image=LOBRDG26
@@ -29949,7 +29954,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG27]
 Image=LOBRDG27
@@ -29957,7 +29962,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=false
-RadarInvisible = true
+RadarInvisible=true
 
 [LOBRDG28]
 Image=LOBRDG28
@@ -29965,7 +29970,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=false
-RadarInvisible = true
+RadarInvisible=true
 
 [LOBRDGE1]
 Image=LOBRDGE1
@@ -30001,7 +30006,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB02]
 Image=LOBRDB02
@@ -30009,7 +30014,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB03]
 Image=LOBRDB03
@@ -30017,7 +30022,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB04]
 Image=LOBRDB04
@@ -30025,7 +30030,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB05]
 Image=LOBRDB05
@@ -30033,7 +30038,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB06]
 Image=LOBRDB06
@@ -30041,7 +30046,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB07]
 Image=LOBRDB07
@@ -30049,7 +30054,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB08]
 Image=LOBRDB08
@@ -30057,7 +30062,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB09]
 Image=LOBRDB09
@@ -30065,7 +30070,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB10]
 Image=LOBRDB10
@@ -30073,7 +30078,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB11]
 Image=LOBRDB11
@@ -30081,7 +30086,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB12]
 Image=LOBRDB12
@@ -30089,7 +30094,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB13]
 Image=LOBRDB13
@@ -30097,7 +30102,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB14]
 Image=LOBRDB14
@@ -30105,7 +30110,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB15]
 Image=LOBRDB15
@@ -30113,7 +30118,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB16]
 Image=LOBRDB16
@@ -30121,7 +30126,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB17]
 Image=LOBRDB17
@@ -30129,7 +30134,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB18]
 Image=LOBRDB18
@@ -30137,7 +30142,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB19]
 Image=LOBRDB19
@@ -30145,7 +30150,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB20]
 Image=LOBRDB20
@@ -30153,7 +30158,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB21]
 Image=LOBRDB21
@@ -30161,7 +30166,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB22]
 Image=LOBRDB22
@@ -30169,7 +30174,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB23]
 Image=LOBRDB23
@@ -30177,7 +30182,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB24]
 Image=LOBRDB24
@@ -30185,7 +30190,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB25]
 Image=LOBRDB25
@@ -30193,7 +30198,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB26]
 Image=LOBRDB26
@@ -30201,7 +30206,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB27]
 Image=LOBRDB27
@@ -30209,7 +30214,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=false
-RadarInvisible = true
+RadarInvisible=true
 
 [LOBRDB28]
 Image=LOBRDB28
@@ -30217,7 +30222,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=false
-RadarInvisible = true
+RadarInvisible=true
 
 [LOBRDGB1]
 Image=LOBRDGB1
@@ -30272,7 +30277,7 @@ NoUseTileLandType=false
 
 [BRIDGE1]
 Image=BRIDGE
-Name = Bridge 1
+Name=Bridge 1
 LegalTarget=true
 RadarColor=115,115,115;92,92,92
 Overrides=yes
@@ -30280,7 +30285,7 @@ NoUseTileLandType=false
 
 [BRIDGE2]
 Image=BRIDGE
-Name = Bridge 2
+Name=Bridge 2
 LegalTarget=true
 RadarColor=115,115,115;92,92,92
 Overrides=yes
@@ -30288,7 +30293,7 @@ NoUseTileLandType=false
 
 [BRIDGEB1]
 Image=BRIDGB
-Name = Wood Bridge 1
+Name=Wood Bridge 1
 LegalTarget=true
 RadarColor=115,115,115;92,92,92
 Overrides=yes
@@ -30296,7 +30301,7 @@ NoUseTileLandType=false
 
 [BRIDGEB2]
 Image=BRIDGB
-Name = Wood Bridge 2
+Name=Wood Bridge 2
 LegalTarget=true
 RadarColor=115,115,115;92,92,92
 Overrides=yes
@@ -30438,7 +30443,7 @@ Land=Rock
 ; element than a game object) called smudges. These typically
 ; are used to mark the effects of battle.
 
-; Crater = Is this a crater smudge [special growth logic] (def=no)?
+; Crater=Is this a crater smudge [special growth logic] (def=no)?
 [CRATER01]
 Crater=yes
 
@@ -30573,13 +30578,13 @@ Height=2
 ; terrain types. The primary purpose is to differentiate the
 ; movement capabilities.
 
-; Float = % of full speed for ships [0 means impassable] (def=100)
-; Foot = % of full speed for foot soldiers [0 means impassable] (def=100)
-; Track = % of full speed for tracked vehicles [0 means impassable] (def=100)
-; Wheel = % of full speed for wheeled vehicles [0 means impassable] (def=100)
-; Hover = % of full speed for hovering vehicles [0 means impassable] (def=100)
-; Amphibious = % of full speed for amphibious vehicles [0 impassable] (def=100)
-; Buildable = Can buildings be built upon this terrain (def=no)?
+; Float=% of full speed for ships [0 means impassable] (def=100)
+; Foot=% of full speed for foot soldiers [0 means impassable] (def=100)
+; Track=% of full speed for tracked vehicles [0 means impassable] (def=100)
+; Wheel=% of full speed for wheeled vehicles [0 means impassable] (def=100)
+; Hover=% of full speed for hovering vehicles [0 means impassable] (def=100)
+; Amphibious=% of full speed for amphibious vehicles [0 impassable] (def=100)
+; Buildable=Can buildings be built upon this terrain (def=no)?
 
 ; clear grassy terrain
 ;[Clear]
@@ -30779,14 +30784,14 @@ Squad=0,<none>,no                 ; squad of random infantry
 2=Vinifera
 3=Aboreus
 
-; Name = display name
-; Image = image to use [1=small, 2=large, 3=vine]
-; Value = credit value per 'bail'
-; Growth = growth rate
-; Spread = spread rate
-; Power = explosive power per 'bail' (def=0)
-; Color = display color of the Tiberium
-; Shard = crystal to fly off when chain reacting (def=none)
+; Name=display name
+; Image=image to use [1=small, 2=large, 3=vine]
+; Value=credit value per 'bail'
+; Growth=growth rate
+; Spread=spread rate
+; Power=explosive power per 'bail' (def=0)
+; Color=display color of the Tiberium
+; Shard=crystal to fly off when chain reacting (def=none)
 
 ; This is Ore
 [Riparius]
@@ -30847,14 +30852,14 @@ Debris=CRYSTAL1,CRYSTAL2,CRYSTAL3,CRYSTAL4
 ; the program, but there are some behavior characteristics that can
 ; be overridden. Don't modify these.
 
-; NoThreat = Is its weapons disabled and thus ignored as a potential target until fired upon (def=no)?
-; Zombie = Is forced to sit there like a zombie and never recovers (def=no)?
-; Recruitable = Can it be recruited into a team or base defense (def=yes)?
-; Paralyzed = Is the object frozen in place but can still fire and function (def=no)?
-; Retaliate = Is allowed to retaliate while on this mission (def=yes)?
-; Scatter = Is allowed to scatter from threats (def=yes)?
-; Rate = delay between normal processing (larger = faster game, less responsiveness)
-; AARate = anti-aircraft delay rate (if not specifed it uses regular rate).
+; NoThreat=Is its weapons disabled and thus ignored as a potential target until fired upon (def=no)?
+; Zombie=Is forced to sit there like a zombie and never recovers (def=no)?
+; Recruitable=Can it be recruited into a team or base defense (def=yes)?
+; Paralyzed=Is the object frozen in place but can still fire and function (def=no)?
+; Retaliate=Is allowed to retaliate while on this mission (def=yes)?
+; Scatter=Is allowed to scatter from threats (def=yes)?
+; Rate=delay between normal processing (larger=faster game, less responsiveness)
+; AARate=anti-aircraft delay rate (if not specifed it uses regular rate).
 
 ; Unit sits still and plays dead.
 [Sleep]
@@ -30995,31 +31000,31 @@ Rate=.1
 Rate=.016
 
 ; ******* Voxel Debris types *******
-; Translucent = is the debris to be drawn with translucency (def=no)?
-; Elasticity = "bounciness" of the object [should be 0.0 through 1.0] (def=0.75)
-; MinAngularVelocity = minimum rate at which the debris is to spin in degrees (def=0.0)
-; MaxAngularVelocity = maximum rate at which the debris is to spin in degrees (def=10.0)
-; Duration = max number of frames to let the debris exist (def=30)
-; MinZVel = minimum starting Z velocity (def=3.5)
-; MaxZVel = maximum starting Z velocity (def=5.0)
-; MaxXYVel = maximim starting lateral velocity (def=15.0)
-; ShareBodyData = Get the voxel data from another Type's body voxel data (def = no)?
-; ShareTurretData = Get the voxel data from another Type's turret voxel data (def = no)?
-; ShareBarrelData = Get the VOXEL data from another Type's barrel voxel data (def = no)?
-; ShareSource = name of the object to share voxel data from (def = none)
-; VoxelIndex = voxel piece within the voxel data to use (def = 0)
-; StartSound = sound to play when the voxel anim is created (def = VOC_NONE).
-; BounceSound = sound to play when the voxel anim bounces (def = VOC_NONE).
-; ExpireSound = sound to play when the voxel anim expires (def = VOC_NONE).
-; BounceAnim = animation to launch when the voxel anim bounces (def = ANIM_NONE).
-; ExpireAnim = animation to launch when the voxel anim expires (def = ANIM_NONE).
-; TrailerAnim = animation to trail behind the object (usually smoke or flame)
-; DamageRadius = the debris damages objects that it hits if they're closer than this distance
-; Damage = amount of damage to apply to objects that are hit
-; Warhead = warhead to use for damage purposes
-; AttachedSystem = particle system to attach to the voxel anim
-; Spawns = the particle spawned when this voxel debris explodes (def = none)
-; SpawnCount = number of particles spawned [on average] (def = 0)
+; Translucent=is the debris to be drawn with translucency (def=no)?
+; Elasticity="bounciness" of the object [should be 0.0 through 1.0] (def=0.75)
+; MinAngularVelocity=minimum rate at which the debris is to spin in degrees (def=0.0)
+; MaxAngularVelocity=maximum rate at which the debris is to spin in degrees (def=10.0)
+; Duration=max number of frames to let the debris exist (def=30)
+; MinZVel=minimum starting Z velocity (def=3.5)
+; MaxZVel=maximum starting Z velocity (def=5.0)
+; MaxXYVel=maximim starting lateral velocity (def=15.0)
+; ShareBodyData=Get the voxel data from another Type's body voxel data (def=no)?
+; ShareTurretData=Get the voxel data from another Type's turret voxel data (def=no)?
+; ShareBarrelData=Get the VOXEL data from another Type's barrel voxel data (def=no)?
+; ShareSource=name of the object to share voxel data from (def=none)
+; VoxelIndex=voxel piece within the voxel data to use (def=0)
+; StartSound=sound to play when the voxel anim is created (def=VOC_NONE).
+; BounceSound=sound to play when the voxel anim bounces (def=VOC_NONE).
+; ExpireSound=sound to play when the voxel anim expires (def=VOC_NONE).
+; BounceAnim=animation to launch when the voxel anim bounces (def=ANIM_NONE).
+; ExpireAnim=animation to launch when the voxel anim expires (def=ANIM_NONE).
+; TrailerAnim=animation to trail behind the object (usually smoke or flame)
+; DamageRadius=the debris damages objects that it hits if they're closer than this distance
+; Damage=amount of damage to apply to objects that are hit
+; Warhead=warhead to use for damage purposes
+; AttachedSystem=particle system to attach to the voxel anim
+; Spawns=the particle spawned when this voxel debris explodes (def=none)
+; SpawnCount=number of particles spawned [on average] (def=0)
 
 [PIECE]
 Name=Scrap Metal Debris
@@ -31137,7 +31142,7 @@ Duration=70
 ExpireAnim=TWLT070
 Damage=500
 DamageRadius=300
-Warhead=Meteorite
+Warhead=TankOGas; Meteorite - Meteorite doesn't exist. Changed to TankOGas to avoid potential errors. Almost never used.
 IsMeteor=true
 Spawns=PEBBLE
 SpawnCount=5
@@ -31155,7 +31160,7 @@ Duration=70
 ExpireAnim=TWLT100
 Damage=500
 DamageRadius=300
-Warhead=Meteorite
+Warhead=TankOGas; Meteorite - Meteorite doesn't exist. Changed to TankOGas to avoid potential errors. Almost never used.
 IsMeteor=true
 IsTiberium=true
 Spawns=PEBBLE

--- a/game-assets/ra2mode.pack/artmd.ini
+++ b/game-assets/ra2mode.pack/artmd.ini
@@ -6431,7 +6431,7 @@ MuzzleFlash9=-41,40
 CanBeHidden=False
 OccupyHeight=4
 DamageFireOffset0=19,31
-damageFireOffset1=-43,25
+DamageFireOffset1=-43,25
 RemoveOccupy1=-2,0
 RemoveOccupy2=-2,1
 RemoveOccupy3=-2,2
@@ -6501,7 +6501,7 @@ ActiveAnim=NAPSYB_A
 ActiveAnimDamaged=NAPSYB_AD
 ActiveAnimZAdjust=-75
 ActiveAnimYSort=100
-CanBeHidden-False
+;CanBeHidden-False
 OccupyHeight=3
 RemoveOccupy1=0,-1
 RemoveOccupy2=-1,0
@@ -6774,7 +6774,7 @@ MuzzleFlash7=-34,2
 MuzzleFlash8=-31,55
 MuzzleFlash9=20,0
 DamageFireOffset0=100,-53
-DamageFireOffset0-37,33
+DamageFireOffset1=-37,33
 CanHideThings=true
 CanBeHidden=false
 OccupyHeight=7
@@ -9611,7 +9611,7 @@ DamageFireOffset0=40,30
 [CALA14]
 Normalized=yes
 Remapable=no
-Foundation=3X3
+Foundation=3x3
 Height=6
 ;Buildup=CAHOSP
 NewTheater=yes
@@ -9640,7 +9640,7 @@ DamageFireOffset1=-9,-27
 [CALA15]
 Normalized=yes
 Remapable=no
-Foundation=3X3
+Foundation=3x3
 Height=6
 ;Buildup=CAHOSP
 NewTheater=yes
@@ -12640,8 +12640,6 @@ Panic=8,6,6
 ; SpawnDelay = number of frames between anim spawns (def=3)
 ; AnimPalette = Does it use the animation palette palette (def=no)?
 [120MM]
-
-[PARABOMB]
 
 [MEDUSA]			; Aegis
 ;Trailer=DURASMOKE
@@ -16849,7 +16847,7 @@ YSortAdjust=-200
 [GTGCAN]
 Remapable=yes
 NewTheater=yes
-Cameo= GCANICON
+Cameo=GCANICON
 Foundation=2x2
 Height=3	; experiment with this
 Buildup=GTGCANMK
@@ -16897,10 +16895,6 @@ UseNormalLight=yes
 
 [TSTIMPCT]
 Normalized=yes
-
-[MININUKE]
-Normalized=yes
-Report=ExplosionBarrel
 
 [MININUKE]
 Normalized=yes

--- a/game-assets/ra2mode.pack/rulesmd.ini
+++ b/game-assets/ra2mode.pack/rulesmd.ini
@@ -239,7 +239,7 @@ PParatrooper=E1          ; infantry that is dropped as a paratrooper
 
 ChronoDelay=60			;delay after teleport for chrono sphere
 ChronoReinfDelay=180	;delay after teleport for chrono reinforcements
-ChronoDistanceFactor=48	;default = 32 amount to divide the distance to destination by to get the warped out delay
+ChronoDistanceFactor=48	;default=32 amount to divide the distance to destination by to get the warped out delay
 ChronoTrigger=yes		;defualt=yes, if yes, then delay varies by distance, if no, it's a constant
 ChronoMinimumDelay=16	;default=0;this is the minimum delay for teleporting, no matter how short the distance
 						;this value will also be used if the ChronoTrigger flag is turned off
@@ -270,7 +270,7 @@ SovParaDropNum=9 ;How many of each of those infantry
 ;*** Spy stuff ***
 AlliedDisguise=E1
 SovietDisguise=E2 ; these are the defaults for the spy if a MakeupKit hasn't been used
-SpyPowerBlackout=1000 ; Frame time a spy shuts down power for (900 = 1 minute)
+SpyPowerBlackout=1000 ; Frame time a spy shuts down power for (900=1 minute)
 SpyMoneyStealPercent=.5 ; Percent of total money you take with a spy
 AttackCursorOnDisguise=no ;gs If yes, the mouse will be an attack cursor on a disguised unit as if he is not disguised.
 								;If no, you will still get an attack cursor on a fake-blinking Mirage and a spy _always_
@@ -332,7 +332,7 @@ TunnelSpeed=1
 MultipleFactory=0.8       ; Ick.  This is now a straight discount multiplier that is cumulative.  ie at .8 you get 1, .8, .64, .512 instead of 1, 1, 1.25,etc   ;gs factory bonus for multiples [1=full bonus, 0=no bonus] (def=1) <--their way at 1 you get 1, 1, .5, .33, .25, etc
 MinLowPowerProductionSpeed=.5   ; minimum production speed as result of low power (def=.5) ;gs applies after modifer below
 MaxLowPowerProductionSpeed=.8 ; and since most of the time you will be short by only 10 or 20, this is the maximum speed you can build if you have low power (so 99% power is treated as this %)
-LowPowerPenaltyModifier=1 ;gs "double penalty" or "half penalty".  multiply this by the power short to get the actual penalty ( def=1. 2 means 30% short = 60% penalty, .5 would mean 15% penalty.)
+LowPowerPenaltyModifier=1 ;gs "double penalty" or "half penalty".  multiply this by the power short to get the actual penalty ( def=1. 2 means 30% short=60% penalty, .5 would mean 15% penalty.)
 
 ; hack section
 GDIGateOne=GAGATE_A      ; these buildings affect nearby walls, so I need to know what they are
@@ -369,7 +369,7 @@ LeptonsPerSightIncrease=2000 ;how high does a unit have to go before it can see 
 LeptonsPerFireIncrease=2000 ; how high does a unit have to go before it can fire farther?
 AttackingAircraftSightRange=2 ; //gs 6 Makes the V3 ping the map.  Hi, welcome to dumb ideas.
 BlendedFog=yes          ; should we blend the fog (as opposed to dither it)
-CliffBackImpassability=2 ; how impassable is it behind cliffs? (0 = minimal, 2 = maximal)
+CliffBackImpassability=2 ; how impassable is it behind cliffs? (0=minimal, 2=maximal)
 IceCrackingWeight=50.0   ; objects weighing more than this will crack ice
 IceBreakingWeight=50.0   ; objects weighing more than this well break through ice
 ShipSinkingWeight=3.0	; Surface ships of this or greater weight will sink, not explode, when destroyed.
@@ -518,9 +518,9 @@ OreTwinkle=TWNK1                      ; This is the anim to use for the Ore Twin
 CreateInfantrySound=	; default sound to use when a new infantry person is created
 CreateUnitSound=				; default sound to use when a new unit is created
 CreateAircraftSound=		; default sound to use when a new aircraft is created
-;IFVTransformSound= IFVTransform	; sound to use when a IFV changes turret ; use EnterTransportSound instead
-SpySatActivationSound= SpyUplinkOn ;	sound to play when spysat comes online
-SpySatDeactivationSound= SpyUplinkOff ;	sound to play when spysat goes offline
+;IFVTransformSound=IFVTransform	; sound to use when a IFV changes turret ; use EnterTransportSound instead
+SpySatActivationSound=SpyUplinkOn ;	sound to play when spysat comes online
+SpySatDeactivationSound=SpyUplinkOff ;	sound to play when spysat goes offline
 ;PsychicSensorDetectAttach=	PsychicSensorDetects ;sound to play when sensor detects an attack (not hooked up yet)
 UpgradeVeteranSound=UpgradeVeteran
 UpgradeEliteSound=UpgradeElite
@@ -580,7 +580,7 @@ DropPod=DROPPOD,DROPPOD2 ; mark to leave after drop pod lands
 DeadBodies=DEATH_A,DEATH_B,DEATH_C,DEATH_D,DEATH_E,DEATH_F   ; choice of dead bodies to leave around
 MetallicDebris=DBRIS1LG,DBRIS2LG,DBRIS3LG,DBRIS4LG,DBRIS5LG,DBRIS6LG,DBRIS7LG,DBRIS8LG,DBRIS9LG,DBRS10LG,DBRIS1SM,DBRIS2SM,DBRIS3SM,DBRIS4SM,DBRIS5SM,DBRIS6SM,DBRIS7SM,DBRIS8SM,DBRIS9SM,DBRS10SM
 BridgeExplosions=TWLT026,TWLT036,TWLT050,TWLT070	; the explosions to use for the bridge explosion effect
-//DigSound=SUBDRIL1       ; SJM: HACK below; sound when digging into the ground
+;DigSound=SUBDRIL1       ; SJM: HACK below; sound when digging into the ground
 DigSound=NukeSiren		; HACK: Nuke siren here since I believe this is unused and we are cramming for the demo
 ;GEF Dig=DIG                 ; anim to play when unit digs into ground
 IonBlast=RING1          ; initial anim when ion cannon hits
@@ -628,7 +628,7 @@ MovieOn=MovieOn         ; movie activation sound
 MovieOff=MovieOff       ; movie deactivation sound
 ScoldSound=MenuScold       ; generic scold sound
 TeslaCharge=TeslaCoilPowerUp    ; tesla charge up sound
-TeslaZap=       ; tesla zap sound
+TeslaZap=; tesla zap sound
 BuildingDamageSound=BuildingDamaged    ; sound when building is damaged to half strength
 ChuteSound=ParachuteDrop         ; parachute deploy sound
 GenericClick=MenuClick    ; generic click sound
@@ -640,7 +640,7 @@ ScatterSound=CommandBar		;Sound when units are commanded to scatter
 DeploySound=		;Sound when units are commanded to deploy
 StormSound=WeatherIntro		; PCG. Sound when weather controller storm starts.
 LightningSounds=WeatherStrike ; PCG. Sounds for various lightning bolts.
-ShellButtonSlideSound= ; PCG; Sound for the shell buttons sliding into position.
+ShellButtonSlideSound=; PCG; Sound for the shell buttons sliding into position.
 ;GEF TreeFire=FIRE2,FIRE1    ; small and large fires to attach to burning trees
 ;GEF OnFire=FIRE3,FIRE2,FIRE1 ; list of flames to use when something catches fire [must be 3 in list]gui
 
@@ -736,8 +736,8 @@ Scorches1=BURN05,BURN06,BURN07 ; scorch mark smudge types
 Scorches2=BURN08,BURN09,BURN10 ; scorch mark smudge types
 Scorches3=BURN11,BURN12,BURN13 ; scorch mark smudge types
 Scorches4=BURN14,BURN15,BURN16 ; scorch mark smudge types
-TiberiumExplosionDamage = 0 ; the amount of damage dealt out by explosion in a big tiberium chain reaction
-TiberiumStrength = -1 ;	the higher this value, the harder it is to get big tiberium to explode
+TiberiumExplosionDamage=0 ; the amount of damage dealt out by explosion in a big tiberium chain reaction
+TiberiumStrength=-1 ;	the higher this value, the harder it is to get big tiberium to explode
 Craters=CR1,CR2,CR3,CR4,CR5,CR6   ; crater smudge types
 AtomDamage=1000      ; damage points when nuclear bomb explodes (regardless of source)
 BallisticScatter=1.0 ; maximum scatter distance (cells) for inaccurate ballistic projectiles (Note: Flak Cannon uses this)
@@ -749,7 +749,7 @@ DMislWarhead=DMISLWH ; this is the warhead on a DredMissile
 V3EliteWarhead=V3EWH       ; this is the warhead on a V3 Rocket when the launcher is elite
 DMislEliteWarhead=DMISLEWH ; this is the warhead on a DredMissile when the launcher is elite
 
-***Crazy Ivan stuff***
+;***Crazy Ivan stuff***
 IvanWarhead=IvanWH   ;gs Since Ivan's weapon plants the bomb, exploding the bomb needs its own WH
 IvanDamage=400      ;gs and since Weapons don't have own life damage is needed seperately ;was 400
 IvanTimedDelay=450	;gs frame delay of an Ivan Time Bomb
@@ -804,7 +804,7 @@ MindControlAttackLineFrames=20;gs how long to draw the act of mind controlling r
 
 
 
-// PCG; Provides knobs to tweak for radiation used by desolater and friends.
+; PCG; Provides knobs to tweak for radiation used by desolater and friends.
 [Radiation]
 RadDurationMultiple=1		; Number of frames site lasts per level of radiation.
 							; When rad level goes to zero, rad site deletes itself.
@@ -828,7 +828,7 @@ RadColor=0,255,0			; The color of the radiation.
 RadSiteWarhead=RadSite		; Sets the warhead used by irradiated tiles.
 
 
-// PCG; Enables customization of the effects elevation has on firing.
+; PCG; Enables customization of the effects elevation has on firing.
 [ElevationModel]
 ElevationIncrement=4			; Number of levels between source and target for a range bonus to kick in.
 ElevationIncrementBonus=2		; Amount of range bonus to add for each elevation increment (NOT map level) between source and target.
@@ -837,7 +837,7 @@ ElevationIncrementBonus=2		; Amount of range bonus to add for each elevation inc
 								; source and target.
 ElevationBonusCap=2				; Cap on range bonuses, to prevent increased average scanning cost for rare situations.
 
-// PCG; Enables customization of the effects walls have on shots.
+; PCG; Enables customization of the effects walls have on shots.
 [WallModel]
 AlliedWallTransparency=no		; If this is yes, allied walls have no effect on the shots of allied units.
 WallPenetratorThreshold=50%		; The amount of damage a unit must inflict before it attempts to fire through walls between it and its target.
@@ -1769,7 +1769,7 @@ Mutant=Special
 180=TROCK05
 181=VEINHOLEDUMMY
 182=CRATE
-;GEF french wall being taken out 183=GAFWLL ;gs Needs own art since an Image= will negate the different stats
+;GEF french wall being taken out 183=GAFWLL ;gs Needs own art since an Image=will negate the different stats
 184=FENCE01
 185=FENCE02
 186=FENCE03
@@ -2353,8 +2353,11 @@ Mutant=Special
 ;840=CAPARS11D
 841=CAPARS12D
 
-842-GAWETH_ED
-843-GAWETH_GD
+; Fixed 842 and 843 by redeclaring at end of list
+; - dont want to mess up any animation indexing for map triggers
+; - RAZER
+;842-GAWETH_ED
+;843-GAWETH_GD
 
 844=CACHIG04D
 
@@ -2528,6 +2531,9 @@ Mutant=Special
 1056=CATIME_A
 
 1072=CANKFGL_A; CCCP84 Nov 2025: it was in unused files. added to ini files and shp to the mix
+
+1073=GAWETH_ED
+1074=GAWETH_GD
 
 ; belonit - additions needed for Ares
 1200=D
@@ -2859,31 +2865,31 @@ Mutant=Special
 ; PCG; 05/02/2K; Added a bunch of stuff to this to try to get everything
 ; controllable from one place.
 ;
-; MinMoney = minimum amount of money selectable in the slider. (def=2500)
-; Money = default amount of money that shows up on the slider. (def=10000)
-; MaxMoney = maximum amount of money selectable in the slider. (def=10000)
-; MoneyIncrement = the amount of money that changes when the slider position
+; MinMoney=minimum amount of money selectable in the slider. (def=2500)
+; Money=default amount of money that shows up on the slider. (def=10000)
+; MaxMoney=maximum amount of money selectable in the slider. (def=10000)
+; MoneyIncrement=the amount of money that changes when the slider position
 ;                  changes its minimum amount. (def=100)
-; MinUnitCount = minumum number of starting units in a game. (def=1)
-; UnitCount = the default starting units. (def=10)
-; MaxUnitCount = maximum number of starting units. (def=20)
-; TechLevel = maximum tech level achievable in a game. (def=10)
-; GameSpeed = starting game speed. For some wacky reason, 0=fastest, 6=slowest. (def=0)
-; AIDifficulty = starting AI difficulty. (def=1)  (0=easy, 1=normal, 2=hard)
-; AIPlayers = starting number of AI players.  Always at least 1 for skirmish.  (def=0)
-; BridgeDestruction = can bridges be destroyed? (def=true)
-; ShadowGrow = deos the shroud regrow? (def=no)  DESUPPORTED.
-; Shroud = is there a shroud on the map? (def=yes)  NOT YET SUPPORTED.
-; Bases = can you build buildings or is this just a unit-to-unit slugfest. (def=yes)  DESUPPORTED.
-; TiberiumGrows = does ore/tiberium/whatever regenerate? (def=yes)
-; Crates = do crates appear in the game? (def=yes)
-; CaptureTheFlag = is this a CTF game? (def=no)  DESUPPORTED.
-; HarvesterTruce = are harvesters immune to enemy fire? (def=no)  DESUPPORTED.
-; MultiEngineer = do you need more than one engineer to take over a building? (def=no)  DESUPPORTED.
-; AlliesAllowed = are allies allowed in this game? (def=no)
-; ShortGame = is a player eliminated when his last building is destroyed? (def=yes)
-; FogOfWar = is there fog of war in this game? (def=no)
-; MCVRedploys = can the player redeploy the MCV? (def=yes)
+; MinUnitCount=minumum number of starting units in a game. (def=1)
+; UnitCount=the default starting units. (def=10)
+; MaxUnitCount=maximum number of starting units. (def=20)
+; TechLevel=maximum tech level achievable in a game. (def=10)
+; GameSpeed=starting game speed. For some wacky reason, 0=fastest, 6=slowest. (def=0)
+; AIDifficulty=starting AI difficulty. (def=1)  (0=easy, 1=normal, 2=hard)
+; AIPlayers=starting number of AI players.  Always at least 1 for skirmish.  (def=0)
+; BridgeDestruction=can bridges be destroyed? (def=true)
+; ShadowGrow=deos the shroud regrow? (def=no)  DESUPPORTED.
+; Shroud=is there a shroud on the map? (def=yes)  NOT YET SUPPORTED.
+; Bases=can you build buildings or is this just a unit-to-unit slugfest. (def=yes)  DESUPPORTED.
+; TiberiumGrows=does ore/tiberium/whatever regenerate? (def=yes)
+; Crates=do crates appear in the game? (def=yes)
+; CaptureTheFlag=is this a CTF game? (def=no)  DESUPPORTED.
+; HarvesterTruce=are harvesters immune to enemy fire? (def=no)  DESUPPORTED.
+; MultiEngineer=do you need more than one engineer to take over a building? (def=no)  DESUPPORTED.
+; AlliesAllowed=are allies allowed in this game? (def=no)
+; ShortGame=is a player eliminated when his last building is destroyed? (def=yes)
+; FogOfWar=is there fog of war in this game? (def=no)
+; MCVRedploys=can the player redeploy the MCV? (def=yes)
 
 [MultiplayerDialogSettings]
 MinMoney=5000
@@ -2966,16 +2972,16 @@ GDIBaseDefenseCoefficient=1.5 ;gs Obsolete.  Use explicit AlliedBaseDefenseCount
 MaximumBaseDefenseValue=60
 ComputerBaseDefenseResponse=3		; how much does the computer overrespond to attacks on its base?
 
-AttackInterval=0.5        ; average delay between computer attacks ; gs obsolete (since forever) use TeamDelays instead
-AttackDelay=0.5           ; average delay time before computer begins first attack
+AttackInterval=0.5      ; average delay between computer attacks ; gs obsolete (since forever) use TeamDelays instead
+AttackDelay=0.5         ; average delay time before computer begins first attack
 PatrolScan=.016         ; minute interval between scanning for enemys while patrolling.
 CreditReserve=100       ; Structure repair will not begin if available cash falls below this amount.
 PathDelay=.01           ; Delay (minutes) between retrying when path is blocked.
 BlockagePathDelay=60	; delay (frames) before unit paths around all blockage
-TiberiumNearScan=6;//gs revert 3; sgc was 6 ; cell radius to scan when harvesting a single patch of Tiberium
+TiberiumNearScan=6		; gs revert 3; sgc was 6 ; cell radius to scan when harvesting a single patch of Tiberium
 TiberiumFarScan=48      ; cells radius to scan when looking for a new Tiberium patch to harvest
 AutocreateTime=1        ; average minutes between creating an 'autocreate' team
-InfantryReserve=50000    ; always build infantry if cash reserve is greater than this
+InfantryReserve=50000   ; always build infantry if cash reserve is greater than this
 InfantryBaseMult=1      ; build infantry if building count times this number is less than current infantry quantity
 PowerSurplus=50         ; build power plants until power surplus is at least this amount
 BaseSizeAdd=3           ; computer base size can be no larger than the largest human opponent, plus this quantity
@@ -3043,17 +3049,17 @@ SellBack=2              ; allowed to sell buildings
 ; by that country. This applies only to multiplayer games and skirmish mode. In
 ; normal game play, all values are "1.0".
 
-; Airspeed = multiplier to speed for all air units [larger means faster] (def=1.0)
-; Armor = multiplier to armor strength for all units and buildings [larger means stronger] (def=1.0)
-; Cost = multiplier to cost for all units and buildings [larger means costlier] (def=1.0)
-; Firepower = multiplier to firepower for all weapons [larger means more damage] (def=1.0)
-; Groundspeed = multiplier to speed for all ground units [larger means faster] (def=1.0)
-; ROF = multiplier to Rate Of Fire for all weapons [larger means slower ROF] (def=1.0)
-; BuildTime = multiplier to general object build time [larger means longer to build] (def=1.0)
-; Color = color to use when displaying objects owned by this country [see color schemes]
-; Multiplay = This house used as placeholder for multiplay house (def=no)?
-; WallOwner = Will this house own walls that are placed near its buildings (def=yes)?
-; SmartAI = Does it presume to have the smart AI logic already enabled (def=no)?
+; Airspeed=multiplier to speed for all air units [larger means faster] (def=1.0)
+; Armor=multiplier to armor strength for all units and buildings [larger means stronger] (def=1.0)
+; Cost=multiplier to cost for all units and buildings [larger means costlier] (def=1.0)
+; Firepower=multiplier to firepower for all weapons [larger means more damage] (def=1.0)
+; Groundspeed=multiplier to speed for all ground units [larger means faster] (def=1.0)
+; ROF=multiplier to Rate Of Fire for all weapons [larger means slower ROF] (def=1.0)
+; BuildTime=multiplier to general object build time [larger means longer to build] (def=1.0)
+; Color=color to use when displaying objects owned by this country [see color schemes]
+; Multiplay=This house used as placeholder for multiplay house (def=no)?
+; WallOwner=Will this house own walls that are placed near its buildings (def=yes)?
+; SmartAI=Does it presume to have the smart AI logic already enabled (def=no)?
 
 ;Enough of theirs.  Here's the real stuff.  VeteranXXX can be used to make all units
 ;of that type start as veterans.  Please stay clear on the meaning of Infantry, Unit, and Aircraft.
@@ -3271,18 +3277,18 @@ SecondText=5,255,225		; Second Text
 ; individual settings. Thus the computer may be playing at 'difficult' level while the
 ; player may be playing at 'easy' level.
 
-; Airspeed = multiplier to speed for all air units (def=1.0)
-; Armor = multiplier to armor strength for all units and buildings (def=1.0)
-; Cost = multiplier to cost for all units and buildings (def=1.0)
-; Firepower = multiplier to firepower for all weapons (def=1.0)
-; Groundspeed = multiplier to speed for all ground units (def=1.0)
-; ROF = multiplier to Rate Of Fire for all weapons [larger means slower ROF] (def=1.0)
-; BuildSlowdown = Should the computer build slower than the player (def=no)?
+; Airspeed=multiplier to speed for all air units (def=1.0)
+; Armor=multiplier to armor strength for all units and buildings (def=1.0)
+; Cost=multiplier to cost for all units and buildings (def=1.0)
+; Firepower=multiplier to firepower for all weapons (def=1.0)
+; Groundspeed=multiplier to speed for all ground units (def=1.0)
+; ROF=multiplier to Rate Of Fire for all weapons [larger means slower ROF] (def=1.0)
+; BuildSlowdown=Should the computer build slower than the player (def=no)?
 ;  <<< affects the computer player, not the human player >>>
-;    ContentScan = Should the contents of a transport be considered when picking best target (def=no)?
-;    RepairDelay = average delay (minutes) between initiating building repair
-;    BuildDelay = average delay (minutes) between initiating construction
-;    DestroyWalls = Allow scanning for nearby enemy walls and destroy them (def=yes)?
+;    ContentScan=Should the contents of a transport be considered when picking best target (def=no)?
+;    RepairDelay=average delay (minutes) between initiating building repair
+;    BuildDelay=average delay (minutes) between initiating construction
+;    DestroyWalls=Allow scanning for nearby enemy walls and destroy them (def=yes)?
 
 [Easy]
 Groundspeed=1.0
@@ -3325,122 +3331,122 @@ DestroyWalls=no
 ; ******* Unit Statistics *******
 ; Specifies the characteristics of the various game objects.
 
-; AllowedToStartInMultiplayer = Can the unit be allocated to a player when starting a multiplayer game (def=yes)
-; Ammo = number of rounds carried between reloads [-1 means unlimited] (def=-1)
-; Armor = the armor type of this object [none,wood,light,heavy,concrete] (def=none);more types added in RA2
-; BuildLimit = arbitrary maximum allowed to build [per house] (def=-1 -- no restriction)
-; Cloakable = Is it equipped with a cloaking device (def=no)?
-; Cost = cost to build object (in credits)
-; Category = category of object [used by AI systems -- "Soldier", "Civilian", "VIP", "Ship",
+; AllowedToStartInMultiplayer=Can the unit be allocated to a player when starting a multiplayer game (def=yes)
+; Ammo=number of rounds carried between reloads [-1 means unlimited] (def=-1)
+; Armor=the armor type of this object [none,wood,light,heavy,concrete] (def=none);more types added in RA2
+; BuildLimit=arbitrary maximum allowed to build [per house] (def=-1 -- no restriction)
+; Cloakable=Is it equipped with a cloaking device (def=no)?
+; Cost=cost to build object (in credits)
+; Category=category of object [used by AI systems -- "Soldier", "Civilian", "VIP", "Ship",
 ;            "Recon", "AFV", "IFV", "LRFS", "Support", "Transport", "AirPower", "AirLift"]
-; CloakStop = Does the unit cloak when stopped moving (def=no)?
-; Crewed = Does it contain a crew that can escape [never infantry] (def=no)?
-; Gunner = Does it change capabilites based on a gunner that has been added. (def=no)
-; CrushSound = sound to play if this object type is crushed (def=none)
-; DeployFire = This unit can fire when deployed. (def=no)
-; DeployFireWeapon = Index of weapon to fire while deployed.  0 or 1.  (def=1)
-; DeployTime = time, in minutes, to deploy or undeploy [if this object can do so]
-; DamageReducesReadiness = Yes if damage to the unit reduces its ammo (because the ammo explodes or becomes detargeted, or whatever) (def=no)
-; Disableable = Can this object be disabled by special multiplay option (def=yes)?
-; DistributedFire = whether the unit continually retargets nearby units and fires at all of them (def=no)
-; DoubleOwned = Can be built/owned by all countries in a multiplayer game (def=no)?
-; EmptyReload = Frames before first reload occurs when unit is empty. -1 means use standard reload time. (def=-1)
-; Explodes = Does it explode violently when destroyed [i.e., does it do collateral damage] (def=no)?
-; Explosion = the explosion to use when it blows up [doesn't apply to infantry] (def=none)
-; FireAngle = pitch of projectile launch and barrel [0 = horizontal, 64 = vertical] (def=50)
-; Gate = Is this building a gate? (def=no)
-; GateCloseDelay = time, in minutes, to delay before closing a gate after it has opened.
-; GuardRange = distance to scan for enemies to attack (def=use weapon range)
-; Image = name of graphic data to use for this object (def=same as object identifier)
-; Immune = Is this object immune to damage
-; ImmuneToPsionics = Is the unit immune to psionics (def=no)?
-; ImmuneToRadiation = Is the unit immune to radiation (def=no)?
-; ImmuneToVeins = Is it immune to vein creature attacks (def=no)?
-; InitialAmmo = number of rounds the unit starts with. -1 means it starts full. (def=-1)
-; Invisible = Is completely and always invisible to enemy (def=no)?
-; Insignificant = Will this object not be announed when destroyed (def=no)?
-; LegalTarget = Is this allowed to be a combat target (def=yes)?
-; Name = specifies the given name (displayed) for the object
-; Nominal = Always use the given name rather than generic "enemy object" (def=no)?
-; OmniFire = Doesn't ever have to rotate to fire. (def=no)
-; OpportunityFire = Can fire at targets while performing other actions, like moving. (def=no).
-; Owner = who can build this [GDI or Nod] (def=none)
-; PipScale = what to base pip display on [Passengers, Tiberium, Ammo, Power] (def=none)
-; PipWrap = how many pips to draw before wrapping (def=none)
-; Points = point value for scoring purposes (def=0)
-; Prerequisite = list of buildings needed before this can be manufactured (def=no requirement)
-; PreventAttackMove = Does this unit know how to do attack-move? (def=<yes, if it has a weapon>)
+; CloakStop=Does the unit cloak when stopped moving (def=no)?
+; Crewed=Does it contain a crew that can escape [never infantry] (def=no)?
+; Gunner=Does it change capabilites based on a gunner that has been added. (def=no)
+; CrushSound=sound to play if this object type is crushed (def=none)
+; DeployFire=This unit can fire when deployed. (def=no)
+; DeployFireWeapon=Index of weapon to fire while deployed.  0 or 1.  (def=1)
+; DeployTime=time, in minutes, to deploy or undeploy [if this object can do so]
+; DamageReducesReadiness=Yes if damage to the unit reduces its ammo (because the ammo explodes or becomes detargeted, or whatever) (def=no)
+; Disableable=Can this object be disabled by special multiplay option (def=yes)?
+; DistributedFire=whether the unit continually retargets nearby units and fires at all of them (def=no)
+; DoubleOwned=Can be built/owned by all countries in a multiplayer game (def=no)?
+; EmptyReload=Frames before first reload occurs when unit is empty. -1 means use standard reload time. (def=-1)
+; Explodes=Does it explode violently when destroyed [i.e., does it do collateral damage] (def=no)?
+; Explosion=the explosion to use when it blows up [doesn't apply to infantry] (def=none)
+; FireAngle=pitch of projectile launch and barrel [0=horizontal, 64=vertical] (def=50)
+; Gate=Is this building a gate? (def=no)
+; GateCloseDelay=time, in minutes, to delay before closing a gate after it has opened.
+; GuardRange=distance to scan for enemies to attack (def=use weapon range)
+; Image=name of graphic data to use for this object (def=same as object identifier)
+; Immune=Is this object immune to damage
+; ImmuneToPsionics=Is the unit immune to psionics (def=no)?
+; ImmuneToRadiation=Is the unit immune to radiation (def=no)?
+; ImmuneToVeins=Is it immune to vein creature attacks (def=no)?
+; InitialAmmo=number of rounds the unit starts with. -1 means it starts full. (def=-1)
+; Invisible=Is completely and always invisible to enemy (def=no)?
+; Insignificant=Will this object not be announed when destroyed (def=no)?
+; LegalTarget=Is this allowed to be a combat target (def=yes)?
+; Name=specifies the given name (displayed) for the object
+; Nominal=Always use the given name rather than generic "enemy object" (def=no)?
+; OmniFire=Doesn't ever have to rotate to fire. (def=no)
+; OpportunityFire=Can fire at targets while performing other actions, like moving. (def=no).
+; Owner=who can build this [GDI or Nod] (def=none)
+; PipScale=what to base pip display on [Passengers, Tiberium, Ammo, Power] (def=none)
+; PipWrap=how many pips to draw before wrapping (def=none)
+; Points=point value for scoring purposes (def=0)
+; Prerequisite=list of buildings needed before this can be manufactured (def=no requirement)
+; PreventAttackMove=Does this unit know how to do attack-move? (def=<yes, if it has a weapon>)
 ;   Can be used to override attack move on units that shouldn't for various reasons.
-; PreventAutoDeploy = Does this unit know how to do auto-deploy? (def=<yes, if the unit support deploying>)
+; PreventAutoDeploy=Does this unit know how to do auto-deploy? (def=<yes, if the unit support deploying>)
 ;	Can be used to override auto deploy on units that deploy.
-; Primary = primary weapon equipped with (def=none)
-; Secondary = secondary weapon equipped with (def=none)
-; ElitePrimary = new primary weapon when at elite veteran status (def=same as primary)
-; EliteSecondary = new secondary weapon when at elite veteran status (def=same as secondary)
-; RadarVisible = Is visible on radar even when under shroud (def=yes [infantry=no])?
-; ROT = Rate Of Turn for body (if present) and turret (if present) (def=0)
-; ReadinessReductionMultiplier = Used to tweak the amount by which damage reduces readiness. 0 cancels the readiness reduction. (def=0)
-; Reload = time delay between reloads (def=0)
-; ReloadIncrement = amount to add at every ((MaxAmmo / PipWrap) %0) increment. Used to slow reload rate increasingly. (def=0)
-; RadarInvisible = Is it invisible on radar maps (def=no)?
-; RadialFireSegments = If this unit has a radial firing pattern, this determines the number
+; Primary=primary weapon equipped with (def=none)
+; Secondary=secondary weapon equipped with (def=none)
+; ElitePrimary=new primary weapon when at elite veteran status (def=same as primary)
+; EliteSecondary=new secondary weapon when at elite veteran status (def=same as secondary)
+; RadarVisible=Is visible on radar even when under shroud (def=yes [infantry=no])?
+; ROT=Rate Of Turn for body (if present) and turret (if present) (def=0)
+; ReadinessReductionMultiplier=Used to tweak the amount by which damage reduces readiness. 0 cancels the readiness reduction. (def=0)
+; Reload=time delay between reloads (def=0)
+; ReloadIncrement=amount to add at every ((MaxAmmo / PipWrap) %0) increment. Used to slow reload rate increasingly. (def=0)
+; RadarInvisible=Is it invisible on radar maps (def=no)?
+; RadialFireSegments=If this unit has a radial firing pattern, this determines the number
 ;    of segments. This starts at the unit's left and goes right over 180 degrees.  (def=0)
-; SelfHealing = Does the object heal automatically up to half strength (def=no)?
-; Selectable = Can this object be selected by the player (def=yes)?
-; Sensors = Has sensors to detect nearby cloaked objects (def=no)?
-; Sight = sight range, in cells (def=1)
-; Size = amount of space unit takes up in cargo hold (def=1)
-; SizeLimit = Max size of unit a transport can carry (def=0) (Size is inclusive. Limit 3 holds 3)
-; Storage = the number of 'bails' this building or unit can store (def=0)
-; Strength = strength (hit points) of this object
-; TargetLaser = Does it have a targeting laser (def=no)?
-; Trainable = Can this object become veteran by experience (def=yes, buildings def=no)?
-; Turret = Is it equipped with a turret like superstructure [never infantry] (def=no)?
-; TurretSpins = Does the turret just sit and spin [only if turret equipped] (def=no)?
-; TechLevel = tech level required to build this [-1 means can't build] (def=-1)
-; ToProtect = Should friendly units come to rescue if under attack [computer only] (def=no)?
-; TypeImmune = Immune to damage from same type objects if owned by same side?
-; UndeployDelay = The time it takes before a unit automatically undeploys. (def=-1)
-; VoiceSelect = list of voices when selecting this object (def=none)
-; VoiceMove = list of voices to use when giving object a movement order (def=none)
-; VoiceAttack = list of voices to use when giving object an attack order (def=none)
-; DieSound = list of voices to use when it dies (def=none)
-; VoiceFeedback = list of voices that may give when taking damage (def=none)
-; Locomotor = CLSID of the object handling movement for this object (def=statue)
-; VeteranAbilities = list of veteran abilities to grant (def=none)
-; EliteAbilities = list of elite abilities to grant cumulative with veteran abilities (def=none)
+; SelfHealing=Does the object heal automatically up to half strength (def=no)?
+; Selectable=Can this object be selected by the player (def=yes)?
+; Sensors=Has sensors to detect nearby cloaked objects (def=no)?
+; Sight=sight range, in cells (def=1)
+; Size=amount of space unit takes up in cargo hold (def=1)
+; SizeLimit=Max size of unit a transport can carry (def=0) (Size is inclusive. Limit 3 holds 3)
+; Storage=the number of 'bails' this building or unit can store (def=0)
+; Strength=strength (hit points) of this object
+; TargetLaser=Does it have a targeting laser (def=no)?
+; Trainable=Can this object become veteran by experience (def=yes, buildings def=no)?
+; Turret=Is it equipped with a turret like superstructure [never infantry] (def=no)?
+; TurretSpins=Does the turret just sit and spin [only if turret equipped] (def=no)?
+; TechLevel=tech level required to build this [-1 means can't build] (def=-1)
+; ToProtect=Should friendly units come to rescue if under attack [computer only] (def=no)?
+; TypeImmune=Immune to damage from same type objects if owned by same side?
+; UndeployDelay=The time it takes before a unit automatically undeploys. (def=-1)
+; VoiceSelect=list of voices when selecting this object (def=none)
+; VoiceMove=list of voices to use when giving object a movement order (def=none)
+; VoiceAttack=list of voices to use when giving object an attack order (def=none)
+; DieSound=list of voices to use when it dies (def=none)
+; VoiceFeedback=list of voices that may give when taking damage (def=none)
+; Locomotor=CLSID of the object handling movement for this object (def=statue)
+; VeteranAbilities=list of veteran abilities to grant (def=none)
+; EliteAbilities=list of elite abilities to grant cumulative with veteran abilities (def=none)
 ;     [FASTER,STRONGER,FIREPOWER,SCATTER,ROF,SIGHT,
 ;      CLOAK,TIBERIUM_PROOF,VEIN_PROOF,SELF_HEAL,EXPLODES,
 ;      RADAR_INVISIBLE,SENSORS,FEARLESS,C4,TIBERIUM_HEAL,
 ;      GUARD_AREA,CRUSHER]
-; LeadershipRating = When the AI needs a representative from a team to make a pathfinding or targeting decision it will pick the one with the highest score (def = 5)
+; LeadershipRating=When the AI needs a representative from a team to make a pathfinding or targeting decision it will pick the one with the highest score (def=5)
 ;  <<< applies only to infantry types >>>
-;    Agent = Does it have spy-like abilities (def=no)?
-;    Fearless = Is not prone to fear (def=no)?
-;    VoiceComment = list of idle voices (def=none)
-;    Pip = color of pip when inside a transport [green,yellow,white,red,blue] (def=green)
-;    C4 = Equipped with building sabotage explosives [presumes Infiltrate is true] (def=no)?
-;    Cyborg = Does it require special cyborg death handling (def=no)?
-;    Fraidycat = Is it inherently afraid and will panic easily (def=no)?
-;    TiberiumProof = Is it immune to tiberium and tiberium gas damage (def=no)?
-;    Infiltrate = Can it enter a building like a spy or thief (def=no)?
-;    IsCanine = Should special case dog logic be applied to this?
-;    Civilian = Counts a civilian for evac and kill tracking (def=no)?
-;    FemaleVoice = Uses the civilian female voice (def=no)?
-;    Engineer = Does it behave like an engineer as far as repair and capture go (def=no)?
-;    Disguised = Is it disguised as enemy soldier when seen by enemy (def=no)?
-;    Agent = Does this infantry gather information if it enters an enemy building [like a spy] (def=no)?
-;    Thief = Does it steal money if it infiltrates an enemy building (def=no)?
-;    VehicleThief = Does it steal enemy vehicles when it gets close to one (def=no)?
-;    Deployer = Deploys like NOD artillery from TibSun. (def=no)
+;    Agent=Does it have spy-like abilities (def=no)?
+;    Fearless=Is not prone to fear (def=no)?
+;    VoiceComment=list of idle voices (def=none)
+;    Pip=color of pip when inside a transport [green,yellow,white,red,blue] (def=green)
+;    C4=Equipped with building sabotage explosives [presumes Infiltrate is true] (def=no)?
+;    Cyborg=Does it require special cyborg death handling (def=no)?
+;    Fraidycat=Is it inherently afraid and will panic easily (def=no)?
+;    TiberiumProof=Is it immune to tiberium and tiberium gas damage (def=no)?
+;    Infiltrate=Can it enter a building like a spy or thief (def=no)?
+;    IsCanine=Should special case dog logic be applied to this?
+;    Civilian=Counts a civilian for evac and kill tracking (def=no)?
+;    FemaleVoice=Uses the civilian female voice (def=no)?
+;    Engineer=Does it behave like an engineer as far as repair and capture go (def=no)?
+;    Disguised=Is it disguised as enemy soldier when seen by enemy (def=no)?
+;    Agent=Does this infantry gather information if it enters an enemy building [like a spy] (def=no)?
+;    Thief=Does it steal money if it infiltrates an enemy building (def=no)?
+;    VehicleThief=Does it steal enemy vehicles when it gets close to one (def=no)?
+;    Deployer=Deploys like NOD artillery from TibSun. (def=no)
 ;  <<< applies only to moving units (not buildings) >>>
-;    MoveToShroud = Allowed to move into a shrouded cell (def=yes, aircraft def=no)?
-;    Dock = preferred docking building [e.g., harvester -> refinery, helicopter -> helipad] (def=none)
-;    TiberiumHeal = Does it heal slowly when in Tiberium field (def=no)?
-;    Passengers = number of passengers it may carry (def=0)
-;    Speed = speed of this object [n/a for buildings] (def=0)
-;    ManualReload = Must this object reload by coordinating with reloader building (def=no)?
-;    WalkRate = walking animation rate [larger means slower] (def=1)
+;    MoveToShroud=Allowed to move into a shrouded cell (def=yes, aircraft def=no)?
+;    Dock=preferred docking building [e.g., harvester -> refinery, helicopter -> helipad] (def=none)
+;    TiberiumHeal=Does it heal slowly when in Tiberium field (def=no)?
+;    Passengers=number of passengers it may carry (def=0)
+;    Speed=speed of this object [n/a for buildings] (def=0)
+;    ManualReload=Must this object reload by coordinating with reloader building (def=no)?
+;    WalkRate=walking animation rate [larger means slower] (def=1)
 ;    IsSelectableCombatant=Does this unit get selected by the select all combatants key? (def=no)
 ;  <<< applies only to turret changers >>>
 ;    TurretCount=the number of turrets the unit has (def=0)
@@ -3448,63 +3454,63 @@ DestroyWalls=no
 ;    YTurretIndex=the number of the weapon for this turret (as indicated by the WeaponX parameter), where Y is the name of swapping factor for the turret (def=none)
 ;    HasTurretTooltips=whether this unit multiplexes tooltips based on its current turret. (def=no)
 ;  <<< applies only to terrestrial driving vehicle types >>>
-;    CrateGoodie = Can it appear out of a crate in multiplay (def=no)?
-;    Crushable = Can it be crushed by a heavy tracked vehicle (def=no)?
-;    Crusher = Is this vehicle able to crush infantry (def=no)?
-;    MovingFire = The vehicle does not need to stop before it can fire (def=yes)?
-;    DeployToFire = The vehicle must deploy before it can fire (def=no)?
-;    Harvester = Does the special Tiberium harvesting rules apply (def=no)?
-;    Weeder = Does the special weed-harvesting rules apply (def=no)?
-;    Deployer = Does it deploy before being able to operate (def=no)? OBSOLETE
-;    IsTilter = Does this unit tilt on slopes (def=yes)?
-;    CarriesCrate = Might this unit drop a crate when it is destroyed (def=no)?
+;    CrateGoodie=Can it appear out of a crate in multiplay (def=no)?
+;    Crushable=Can it be crushed by a heavy tracked vehicle (def=no)?
+;    Crusher=Is this vehicle able to crush infantry (def=no)?
+;    MovingFire=The vehicle does not need to stop before it can fire (def=yes)?
+;    DeployToFire=The vehicle must deploy before it can fire (def=no)?
+;    Harvester=Does the special Tiberium harvesting rules apply (def=no)?
+;    Weeder=Does the special weed-harvesting rules apply (def=no)?
+;    Deployer=Does it deploy before being able to operate (def=no)? OBSOLETE
+;    IsTilter=Does this unit tilt on slopes (def=yes)?
+;    CarriesCrate=Might this unit drop a crate when it is destroyed (def=no)?
 ;  <<< applies only to aircraft >>>
-;    Carryall = Can it tote vehicles around (def=no)?
-;    Landable = Can this aircraft land on the map (def=no)?
-;    PitchSpeed = Throttle setting at which aircraft pitch forward (def=.25);
-;    PitchAngle = Amount that non-FixedWing aircraft pitch forward in degrees (def=20.0);
-;    RollAngle = Amount that the aircraft rolls when turning (def=30.0)
+;    Carryall=Can it tote vehicles around (def=no)?
+;    Landable=Can this aircraft land on the map (def=no)?
+;    PitchSpeed=Throttle setting at which aircraft pitch forward (def=.25);
+;    PitchAngle=Amount that non-FixedWing aircraft pitch forward in degrees (def=20.0);
+;    RollAngle=Amount that the aircraft rolls when turning (def=30.0)
 ;  <<< applies only to building types >>>
-;    Adjacent = distance allowed to place from other buildings (def=1)
-;    BaseNormal = Considered for building adjacency checks (def=yes)? ;HEY!  Use this, not the phantom IsBase
-;    Barrel = Use barrel explosion logic when it is destroyed (def=no)?
-;    Bib = Does the building have a bib built in (def=no)?
-;    Capturable = Can this building be infiltrated by a spy/engineer (def=no)?
-;    DockUnload = When a unit docks with this building should it unload (def=no)?
-;    Factory = type of object to build [InfantryType, AircraftType, UnitType, BuildingType, VesselType] (def=none)
-;    Fake = Is this a fake structure (def=no)?
-;    FreeUnit = free unit to give this building [typically harvester with refinery] (def=none)
-;    Power = power output [positive for output, negative for drain] (def=0)
-;    Powered = Does it require power to function (def=no)?
-;    Radar = Does this building give radar to owning player (def=no)?
-;    Repairable = Can it be repaired (def=yes)?
+;    Adjacent=distance allowed to place from other buildings (def=1)
+;    BaseNormal=Considered for building adjacency checks (def=yes)? ;HEY!  Use this, not the phantom IsBase
+;    Barrel=Use barrel explosion logic when it is destroyed (def=no)?
+;    Bib=Does the building have a bib built in (def=no)?
+;    Capturable=Can this building be infiltrated by a spy/engineer (def=no)?
+;    DockUnload=When a unit docks with this building should it unload (def=no)?
+;    Factory=type of object to build [InfantryType, AircraftType, UnitType, BuildingType, VesselType] (def=none)
+;    Fake=Is this a fake structure (def=no)?
+;    FreeUnit=free unit to give this building [typically harvester with refinery] (def=none)
+;    Power=power output [positive for output, negative for drain] (def=0)
+;    Powered=Does it require power to function (def=no)?
+;    Radar=Does this building give radar to owning player (def=no)?
+;    Repairable=Can it be repaired (def=yes)?
 ;		RevealToAll=yes Means that when built or captured, a radar event is generated (def=no)
-;    UnitReload = Does this building reload units if they dock with it (def=no)?
-;    UnitRepair = Does this building repair units if they dock with it (def=no)?
-;    Unsellable = Cannot sell this building (even if it can be built)?
-;    Wall = Is this a wall type structure [special rules apply] (def=no)?
-;    WaterBound = Is this building placed on water only (def=no)?
-;    Upgrades = Is the number of power-ups/upgrades that can be applied to this building (def=0)
-;    ShipYard = This building is a ship yard or sub pen
-;    SAM = This building is a SAM launcher
-;    ConstructionYard = This building is a construction yard
-;    Refinery = This building is a tiberium/ore refinery
-;    WeaponsFactory = This building is a weapons factory
-;    CloakGenerator = Does this building cloak objects around it?
-;    LaserFencePost = This building is a laser fence post and obeys the rules for a building of this type.
-;    LightIntensity = This building radiates this amount of light (def = 0).
-;    LightVisibility= The distance (in leptons) that this light is visible from (def=5000).
-;    LightRedTint   = The red tint of this buildings light (def=1.0)
-;    LightGreenTint = The green tint of this buildings light (def=1.0)
-;    LightBlueTint  = The blue tint of this buildings light (def=1.0)
-;    InvisibleInGame= Building cannot be seen on selected in the game, only in the editor. (def=no)
-;    PowersUpBuilding = Building that can be upgraded by attaching this building to it
-;    PowersUpToLevel = Amount of upgrade provided by this attachment. -1=incremental upgrade. Positive number is specific upgrade.
-;    Hospital = Can this building heal infantry (def = no) ?
-;    Armory = Is this building an armory
-;    PlaceAnywhere = Can this building ignore normal placement rules? Only use this for non-player placed buildings (def = no).
-;    Weeder = Is this a weed collection facility (def=no)?
-;    TogglePower = [override] Can be turned on/off under player control or affected by low power (def=yes)?
+;    UnitReload=Does this building reload units if they dock with it (def=no)?
+;    UnitRepair=Does this building repair units if they dock with it (def=no)?
+;    Unsellable=Cannot sell this building (even if it can be built)?
+;    Wall=Is this a wall type structure [special rules apply] (def=no)?
+;    WaterBound=Is this building placed on water only (def=no)?
+;    Upgrades=Is the number of power-ups/upgrades that can be applied to this building (def=0)
+;    ShipYard=This building is a ship yard or sub pen
+;    SAM=This building is a SAM launcher
+;    ConstructionYard=This building is a construction yard
+;    Refinery=This building is a tiberium/ore refinery
+;    WeaponsFactory=This building is a weapons factory
+;    CloakGenerator=Does this building cloak objects around it?
+;    LaserFencePost=This building is a laser fence post and obeys the rules for a building of this type.
+;    LightIntensity=This building radiates this amount of light (def=0).
+;    LightVisibility=The distance (in leptons) that this light is visible from (def=5000).
+;    LightRedTint=The red tint of this buildings light (def=1.0)
+;    LightGreenTint=The green tint of this buildings light (def=1.0)
+;    LightBlueTint=The blue tint of this buildings light (def=1.0)
+;    InvisibleInGame=Building cannot be seen on selected in the game, only in the editor. (def=no)
+;    PowersUpBuilding=Building that can be upgraded by attaching this building to it
+;    PowersUpToLevel=Amount of upgrade provided by this attachment. -1=incremental upgrade. Positive number is specific upgrade.
+;    Hospital=Can this building heal infantry (def=no) ?
+;    Armory=Is this building an armory
+;    PlaceAnywhere=Can this building ignore normal placement rules? Only use this for non-player placed buildings (def=no).
+;    Weeder=Is this a weed collection facility (def=no)?
+;    TogglePower=[override] Can be turned on/off under player control or affected by low power (def=yes)?
 ;
 ;	 WST 6/23/99. Below are new zbuffer adjustment for units
 ;	 ZFudgeCliff // fudge for units behind cliffs showing through rocks
@@ -3525,17 +3531,17 @@ DestroyWalls=no
 ;These will control what can shoot what for the last durn time.  Defaults are 0's
 ;This has no impact on anti/not anti air weapons.  Those already work.
 ;NavalTargeting
-;	UNDERWATER_NEVER = 0,			Can't shoot at all at underwater
-;	UNDERWATER_SECONDARY = 1,	Use Second weapon against underwater
-;	UNDERWATER_ONLY = 2,			Can only shoot underwater
-;	ORGANIC_SECONDARY = 3,		Use second Weapon on organic
-;	SEAL_SPECIAL = 4,					Primary on Amphibious and organic, Second on Naval and underwater-not-organic
-;	NAVAL_ALL = 5,						Go ahead and shoot everything with Primary
-; NAVAL_NONE = 6,						Don't even shoot into the water
+;	UNDERWATER_NEVER=0,			Can't shoot at all at underwater
+;	UNDERWATER_SECONDARY=1,	Use Second weapon against underwater
+;	UNDERWATER_ONLY=2,			Can only shoot underwater
+;	ORGANIC_SECONDARY=3,		Use second Weapon on organic
+;	SEAL_SPECIAL=4,					Primary on Amphibious and organic, Second on Naval and underwater-not-organic
+;	NAVAL_ALL=5,						Go ahead and shoot everything with Primary
+; NAVAL_NONE=6,						Don't even shoot into the water
 
 ;LandTargeting
-;	LAND_OKAY = 0,						Land is okay
-;	LAND_NOT_OKAY = 1,				Land is OK
+;	LAND_OKAY=0,						Land is okay
+;	LAND_NOT_OKAY=1,				Land is OK
 
 ; ******************************
 ; ******* infantry types *******
@@ -7263,8 +7269,8 @@ VoiceAttack=GenAllVehicleAttackCommand
 VoiceFeedback=
 DieSound=GenVehicleDie
 MoveSound=IFVMoveStart
-EnterTransportSound= IFVTransform
-LeaveTransportSound= IFVTransform
+EnterTransportSound=IFVTransform
+LeaveTransportSound=IFVTransform
 MaxDebris=3
 DebrisTypes=TIRE
 DebrisMaximums=6
@@ -8918,8 +8924,8 @@ ThreatPosed=0 ; This value MUST be 0 for all building addons
 DamageParticleSystems=SparkSys,SmallGreySSys,BigGreySmokeSys
 DamageSmokeOffset=395,750,410
 AIBuildThis=yes
-;ExitCoord = 1280,256,0
-;ExitCoord = 610,188,0 ;above - 670 and 68
+;ExitCoord=1280,256,0
+;ExitCoord=610,188,0 ;above - 670 and 68
 ExitCoord=384,96,0 ;gs dude, logically this should be 512,256,0 because 96 is not the center of a cell
 ;The 96 is messing up the CMiner, but fixing it breaks the CMiner even more ;corection to make blimps/jumpjets work
 Spyable=yes
@@ -10665,7 +10671,7 @@ MaxDebris=1
 LightVisibility=4000
 LightIntensity=0.01
 LightRedTint=0.01
-LightGreenTint=0,01
+LightGreenTint=0.01
 LightBlueTint=0.7
 ThreatPosed=0	; This value MUST be 0 for all building addons
 DamageParticleSystems=SparkSys,LGSparkSys
@@ -10864,7 +10870,7 @@ Explosion=TWLT070,S_BANG48,S_BRNL58,S_CLSN58,S_TUMU60
 LightVisibility=4000
 LightIntensity=0.01
 LightRedTint=0.01
-LightGreenTint=0,01
+LightGreenTint=0.01
 LightBlueTint=0.7
 DamageParticleSystems=SparkSys,LGSparkSys
 Powered=true
@@ -11757,6 +11763,31 @@ ProduceCashAmount=20 ; Amount every Delay
 ProduceCashDelay=100 ; Frame delay between Amounts
 WorkingSound=OilDerrickLoop
 LeaveRubble=yes
+
+[CAPOWR]
+UIName=Name:CAPOWR
+Name=Tech Civilian Power Plant
+TechLevel=-1
+Strength=800
+Insignificant=yes
+Nominal=yes
+Sight=6
+Points=5
+Armor=concrete
+Explosion=TWLT070,S_BANG48,S_BRNL58,S_CLSN58,S_TUMU60
+MaxDebris=15
+MinDebris=5
+DebrisAnims=Dbris1sm,Dbris1lg,Dbris4sm,Dbris5sm,Dbris4lg,Dbris7sm,Dbris8sm,Dbris5lg,Dbris4lg
+DamageParticleSystems=SmallGreySSys,BigGreySmokeSys
+Capturable=yes
+CaptureEvaEvent=EVA_TechBuildingCaptured ;Eva (and therefore 3way split) voice to use when captured
+NeedsEngineer=yes
+Unsellable=yes
+Ammo=5
+;SuperWeapon=ParaDropSpecial
+LeaveRubble=yes
+Power=200
+RadarVisible=yes;gs put on radar even if insignificant and unowned (insignificant and owned is a UC building)
 
 ; Use Ammo to specify number of time the building can be used to upgrade infantry
 [CAARMR]
@@ -16395,30 +16426,6 @@ Primary=none
 Secondary=none
 Cost=600
 
-;Einsteins Lab
-[CALAB]
-UIName=Name:EinsteinLab
-Name=RA2 Einstein's Lab
-TechLevel=-1
-Strength=1000
-Insignificant=yes
-Nominal=yes
-RadarInvisible=yes
-Points=5
-Armor=steel
-Explosion=TWLT070,S_BANG48,S_BRNL58,S_CLSN58,S_TUMU60
-MaxDebris=0
-;Selectable=no
-;IsBase=no
-BaseNormal=no ;psst....IsBase isn't a Rules flag
-Sight=6 ; UC base values
-ClickRepairable=no
-CanBeOccupied=yes
-MaxNumberOccupants=10
-;DistributedFire=yes
-CanOccupyFire=Yes
-LeaveRubble=yes
-
 ;Misc Civ Structure
 [CAMOV01]
 UIName=Name:CAMOV01
@@ -18578,27 +18585,27 @@ AntiAirValue=25
 ; The weapons specified here are attached to the various combat
 ; units and buildings.
 
-; Anim = animation to display as a firing effect [use 8 for directional variation]
-; AreaFire = indicates that the weapon fires at the current cell and does damage in a radius (def=no). Warning: This only works for secondary weapons right now.
-; Bright = Does this weapons bullet cause a lighting effect when it impacts (def=no)? If set, this will override the warheads 'Bright' flag.
-; Burst = number of rapid succession shots from this weapon (def=1)
-; Camera = Reveals area around firer (def=no)?
-; Charges = SJM: I have disabled this system.  Use IsAnimDelayedFire in ART.INI instead.  Does it have charge-up-before-firing logic (def=no)?
-; Damage = the amount of damage (unattenuated) dealt with every bullet
-; Floater = floats like a frizbee
-; IonSensitive = Shuts down during an ion storm (def=no)?
-; Lobber = does the projectile fly to target in a high arc (def=no)?
-; MinimumRange = minimum range to target (def=0)
-; Projectile = projectile characteristic to use
-; RadLevel = the radiation level left by the weapon. (def=0)
-; Range = maximum cell range
-; ROF = delay between shots [15 = 1 second at middle speed setting]
-; Report = List of sounds to random play when firing
-; Speed = speed of projectile to target (100 is maximum)
-; Supress = Should nearby friendly buildings be scanned for and if found, discourage firing on target (def=no)?
-; TurboBoost = Should the weapon get a boosted speed bonus when firing upon aircraft?
-; UseFireParticles = Should the weapon spawn a flame particle system? (def = no)
-; Warhead = warhead to attach to projectile
+; Anim=animation to display as a firing effect [use 8 for directional variation]
+; AreaFire=indicates that the weapon fires at the current cell and does damage in a radius (def=no). Warning: This only works for secondary weapons right now.
+; Bright=Does this weapons bullet cause a lighting effect when it impacts (def=no)? If set, this will override the warheads 'Bright' flag.
+; Burst=number of rapid succession shots from this weapon (def=1)
+; Camera=Reveals area around firer (def=no)?
+; Charges=SJM: I have disabled this system.  Use IsAnimDelayedFire in ART.INI instead.  Does it have charge-up-before-firing logic (def=no)?
+; Damage=the amount of damage (unattenuated) dealt with every bullet
+; Floater=floats like a frizbee
+; IonSensitive=Shuts down during an ion storm (def=no)?
+; Lobber=does the projectile fly to target in a high arc (def=no)?
+; MinimumRange=minimum range to target (def=0)
+; Projectile=projectile characteristic to use
+; RadLevel=the radiation level left by the weapon. (def=0)
+; Range=maximum cell range
+; ROF=delay between shots [15=1 second at middle speed setting]
+; Report=List of sounds to random play when firing
+; Speed=speed of projectile to target (100 is maximum)
+; Supress=Should nearby friendly buildings be scanned for and if found, discourage firing on target (def=no)?
+; TurboBoost=Should the weapon get a boosted speed bonus when firing upon aircraft?
+; UseFireParticles=Should the weapon spawn a flame particle system? (def=no)
+; Warhead=warhead to attach to projectile
 
 [DefaultDeathWeapon]
 Projectile=Invisible
@@ -18852,7 +18859,7 @@ OmniFire=yes
 ;Ghost's Rail Gun
 [LtRail]
 Damage=0			; this should be 0 for railgun shots
-AmbientDamage=150	; use this for the railgun damage field.  Leave damage = 0
+AmbientDamage=150	; use this for the railgun damage field.  Leave damage=0
 ROF=60		; ROF for railgun is tied to the duration (MaxEC) of the railgun particle
 Range=6
 Projectile=InvisibleLow
@@ -18865,7 +18872,7 @@ Report=BIGGGUN1
 
 ;Mammoth Rail Gun
 [MechRailgun]
-AmbientDamage=200	; use this for the railgun damage field.  Leave damage = 0
+AmbientDamage=200	; use this for the railgun damage field.  Leave damage=0
 Damage=0			; this should be 0 for railgun shots
 ROF=60		; ROF for railgun is tied to the duration (MaxEC) of the railgun particle
 Range=8
@@ -19574,10 +19581,10 @@ Range=8
 Speed=100
 Projectile=InvisibleHigh
 Warhead=PrismWarhead
-;LaserInnerColor = 216,0,184
-;LaserOuterColor = 80,0,88
-LaserOuterSpread= 0,0,0
-LaserDuration = 15
+;LaserInnerColor=216,0,184
+;LaserOuterColor=80,0,88
+LaserOuterSpread=0,0,0
+LaserDuration=15
 IsLaser=true	; this flag tells the game to use the special laser draw effect
 IsHouseColor=true
 Report=PrismTowerAttack
@@ -19591,10 +19598,10 @@ Range=12
 Speed=25
 Projectile=InvisibleHigh
 Warhead=PrismWarhead
-;LaserInnerColor = 216,0,184
-;LaserOuterColor = 80,0,88
-LaserOuterSpread= 0,0,0
-LaserDuration = 15
+;LaserInnerColor=216,0,184
+;LaserOuterColor=80,0,88
+LaserOuterSpread=0,0,0
+LaserDuration=15
 IsLaser=true	; this flag tells the game to use the special laser draw effect
 IsHouseColor=true
 Report=PrismTowerAttack
@@ -19607,10 +19614,10 @@ Range=8
 Speed=100
 Projectile=InvisibleHigh
 Warhead=DummyWarhead
-;LaserInnerColor = 32,48,216
-;LaserOuterColor = 24,24,96
-LaserOuterSpread= 0,0,0
-LaserDuration = 15
+;LaserInnerColor=32,48,216
+;LaserOuterColor=24,24,96
+LaserOuterSpread=0,0,0
+LaserDuration=15
 IsLaser=true	; this flag tells the game to use the special laser draw effect
 IsHouseColor=true
 
@@ -19700,10 +19707,10 @@ Range=10.5
 Speed=100
 Warhead=Super
 Report=PrismTowerAttack
-LaserInnerColor = 255,0,0
-LaserOuterColor = 0,0,0
-LaserOuterSpread= 20,40,40
-LaserDuration = 15
+LaserInnerColor=255,0,0
+LaserOuterColor=0,0,0
+LaserOuterSpread=20,40,40
+LaserDuration=15
 Projectile=LLine
 IsBigLaser=true
 IsLaser=true	; this flag tells the game to use the special laser draw effect
@@ -19718,10 +19725,10 @@ Speed=100
 Warhead=Super
 Report=LASTUR1
 Charges=no
-LaserInnerColor = 255,0,0
-LaserOuterColor = 0,0,0
-LaserOuterSpread= 20,40,40
-LaserDuration = 15
+LaserInnerColor=255,0,0
+LaserOuterColor=0,0,0
+LaserOuterSpread=20,40,40
+LaserDuration=15
 Projectile=LLine2
 IsLaser=true	; this flag tells the game to use the special laser draw effect
 
@@ -19982,11 +19989,11 @@ Speed=40
 Report=PrismTankAttack
 Warhead=CometWH
 Bright=yes
-;LaserInnerColor = 216,0,184
-;LaserOuterColor = 80,0,88
+;LaserInnerColor=216,0,184
+;LaserOuterColor=80,0,88
 IsHouseColor=true
-LaserOuterSpread= 0,0,0
-LaserDuration = 15
+LaserOuterSpread=0,0,0
+LaserDuration=15
 IsLaser=true	; this flag tells the game to use the special laser draw effect
 
 [CometFragment]
@@ -19997,11 +20004,11 @@ Projectile=SmallCometP
 Speed=10
 Warhead=CometWH
 Bright=yes
-;LaserInnerColor = 216,0,184
-;LaserOuterColor = 80,0,88
+;LaserInnerColor=216,0,184
+;LaserOuterColor=80,0,88
 IsHouseColor=true
-LaserOuterSpread= 0,0,0
-LaserDuration = 15
+LaserOuterSpread=0,0,0
+LaserDuration=15
 IsLaser=true	; this flag tells the game to use the special laser draw effect
 
 [TeslaFragment]
@@ -20080,7 +20087,6 @@ Range=6
 Speed=100
 Projectile=InvisibleLow
 Warhead=ChronoBeam
-Report=
 IsRadBeam=yes
 Report=ChronoLegionAttack
 
@@ -20175,10 +20181,10 @@ Range=12;8
 Speed=100
 Projectile=InvisibleHigh
 Warhead=PrismWarhead
-LaserInnerColor = 216,0,184
-LaserOuterColor = 80,0,88
-LaserOuterSpread= 0,0,0
-LaserDuration = 15
+LaserInnerColor=216,0,184
+LaserOuterColor=80,0,88
+LaserOuterSpread=0,0,0
+LaserDuration=15
 IsBigLaser=true
 IsLaser=true	; this flag tells the game to use the special laser draw effect
 Report=IFVCowshot
@@ -20377,11 +20383,11 @@ Speed=10
 Report=
 Warhead=CometWH
 Bright=yes
-;LaserInnerColor = 216,0,184
-;LaserOuterColor = 80,0,88
+;LaserInnerColor=216,0,184
+;LaserOuterColor=80,0,88
 IsHouseColor=true
-LaserOuterSpread= 0,0,0
-LaserDuration = 15
+LaserOuterSpread=0,0,0
+LaserDuration=15
 IsLaser=true	; this flag tells the game to use the special laser draw effect
 
 [SuperCometFragment]
@@ -20393,11 +20399,11 @@ Speed=10
 Report=
 Warhead=CometWH
 Bright=yes
-;LaserInnerColor = 216,0,184
-;LaserOuterColor = 80,0,88
+;LaserInnerColor=216,0,184
+;LaserOuterColor=80,0,88
 IsHouseColor=true
-LaserOuterSpread= 0,0,0
-LaserDuration = 15
+LaserOuterSpread=0,0,0
+LaserDuration=15
 IsLaser=true	; this flag tells the game to use the special laser draw effect
 
 [MirageGunE]
@@ -20679,36 +20685,36 @@ Report=GIAttackDeployed
 ; to its target. Think of the projectile as the "delivery method" used
 ; to get the warhead to the desired target.
 
-; AA = Can this weapon fire upon flying aircraft (def=no)?
-; AG = Can this weapon fire upon ground objects (def=yes)?
-; AN = Can this weapon fire upon naval objects (def=yes)?
-; AS = Can this weapon fire upon sub-marine objects (def=no)?
-; ASW = Is this an Anti-Submarine-Warfare projectile (def=no)?
-; Acceleration = amount to increase missile speed (def=3)
-; Airburst = Does it try to fly over the target instead of hit it (def=no)?
-; Arcing = Does the bullet travel using an arcing path rather than a straight line? (def=no)
-; Arm = arming delay (def=0)
-; Bouncy = Does it bounce a bit upon impact (def=no)?
-; Cluster = number of explosions attached to projectile [cluster-bomb] (def=1)
-; Color = Color  to use for special remapping projectiles (def = none)
-; CourseLockDuration = How many frames the projectile keep its initial course locked for. (def=0)
-; Degenerates = Does the bullet strength weaken as it travels (def=no)?
-; Dropping = Does it fall from a starting height (def=no)?
-; Level = Does it stay at the same altitude in flight? (Currently also acts as IsTorpedo)
-; Elasticity = "bounciness" of the object [should be 0.0 through 1.0] (def=0.75)
-; Image = image to use during flight
-; Inaccurate = Is it inherently inaccurate (def=no)?
-; Inviso = Is the projectile invisible as it travels (def=no)?
-; Parachuted = Equipped with a parachute for dropping from plane (def=no)?
-; Proximity = Does it blow up when near its target (def=no)?
-; ROT = Rate Of Turn [non zero implies homing] (def=0)
-; Ranged = Can it run out of fuel (def=no)?
-; Scalable = Can its animations be tuned up and down on the fly? (def=no)
-; Shadow = If High, does this bullet need to have a shadow drawn? (def = yes)
-; SubjectToCliffs = Can this bullet be stopped by upward cliffs?  No effect on homing projectiles. (def=no)
-; SubjectToElevation = Can this bullet get a range bonus from height?  No effect on homing projectiles.  (def=no)
-; SubjectToWalls = Can this bullet be stopped by walls?  (def=no)
-; VeryHigh = Does it fly at a very high cruise altitude (def=no)?
+; AA=Can this weapon fire upon flying aircraft (def=no)?
+; AG=Can this weapon fire upon ground objects (def=yes)?
+; AN=Can this weapon fire upon naval objects (def=yes)?
+; AS=Can this weapon fire upon sub-marine objects (def=no)?
+; ASW=Is this an Anti-Submarine-Warfare projectile (def=no)?
+; Acceleration=amount to increase missile speed (def=3)
+; Airburst=Does it try to fly over the target instead of hit it (def=no)?
+; Arcing=Does the bullet travel using an arcing path rather than a straight line? (def=no)
+; Arm=arming delay (def=0)
+; Bouncy=Does it bounce a bit upon impact (def=no)?
+; Cluster=number of explosions attached to projectile [cluster-bomb] (def=1)
+; Color=Color  to use for special remapping projectiles (def=none)
+; CourseLockDuration=How many frames the projectile keep its initial course locked for. (def=0)
+; Degenerates=Does the bullet strength weaken as it travels (def=no)?
+; Dropping=Does it fall from a starting height (def=no)?
+; Level=Does it stay at the same altitude in flight? (Currently also acts as IsTorpedo)
+; Elasticity="bounciness" of the object [should be 0.0 through 1.0] (def=0.75)
+; Image=image to use during flight
+; Inaccurate=Is it inherently inaccurate (def=no)?
+; Inviso=Is the projectile invisible as it travels (def=no)?
+; Parachuted=Equipped with a parachute for dropping from plane (def=no)?
+; Proximity=Does it blow up when near its target (def=no)?
+; ROT=Rate Of Turn [non zero implies homing] (def=0)
+; Ranged=Can it run out of fuel (def=no)?
+; Scalable=Can its animations be tuned up and down on the fly? (def=no)
+; Shadow=If High, does this bullet need to have a shadow drawn? (def=yes)
+; SubjectToCliffs=Can this bullet be stopped by upward cliffs?  No effect on homing projectiles. (def=no)
+; SubjectToElevation=Can this bullet get a range bonus from height?  No effect on homing projectiles.  (def=no)
+; SubjectToWalls=Can this bullet be stopped by walls?  (def=no)
+; VeryHigh=Does it fly at a very high cruise altitude (def=no)?
 
 
 
@@ -21239,10 +21245,10 @@ SubjectToWalls=yes
 
 ; *** Particle Systems ***
 ;
-; HoldsWhat = type of particle (see below) that this system manages (required)
-; Spawns = does this system spawn particles by itself (def = no)
-; SpawnFrames = number of frames to wait before spawning another particle
-; ParticleCap = maximum number of particles that can be in this system
+; HoldsWhat=type of particle (see below) that this system manages (required)
+; Spawns=does this system spawn particles by itself (def=no)
+; SpawnFrames=number of frames to wait before spawning another particle
+; ParticleCap=maximum number of particles that can be in this system
 
 [SmallRailgunSys]
 HoldsWhat=SmallRailgunPart
@@ -21364,17 +21370,17 @@ SpawnSparkPercentage=.2
 
 ; *** Particles ***
 ;
-; Image = Imagelist to use for particle
-; Persistent = Does this particle stick around; should always be yes
-; MaxDC = How many frames go by before this particle damages the things near it? (def = 0)
-; MaxEC = How many frames does this object last (def = 0)
-; Damage = How much damage does it do (def = 0)
-; Warhead = What warhead to use for damage purposes (def = WARHEAD_NONE)
-; StartFrame = what frame of image to start on? (def = 0)
-; NumLoopFrames = how many frames form a single loop? (def = 1)
-; WindEffect = to what degree does the wind affect his particle, 0 = not at all, 5 = a lot (def = 0)
-; Velocity = speed at which particle travels (def = 0.0)
-; Radius = how big is this particle? (used for attract/repel)
+; Image=Imagelist to use for particle
+; Persistent=Does this particle stick around; should always be yes
+; MaxDC=How many frames go by before this particle damages the things near it? (def=0)
+; MaxEC=How many frames does this object last (def=0)
+; Damage=How much damage does it do (def=0)
+; Warhead=What warhead to use for damage purposes (def=WARHEAD_NONE)
+; StartFrame=what frame of image to start on? (def=0)
+; NumLoopFrames=how many frames form a single loop? (def=1)
+; WindEffect=to what degree does the wind affect his particle, 0=not at all, 5=a lot (def=0)
+; Velocity=speed at which particle travels (def=0.0)
+; Radius=how big is this particle? (used for attract/repel)
 ;
 ; BehavesLike, DeleteOnStateLimit, EndStateAI, StateAIAdvance are things that
 ; shouldn't be messed with
@@ -21602,18 +21608,18 @@ ColorSpeed=.13
 ; effect, lacks pinpoint accuracy, and acknowledges the fact that
 ; tanks pose little threat to infantry that take cover.
 
-; Spread = Obsolete.  Kept entries to give benchmark for new spread system
-; Wall = Does this warhead damage concrete walls (def=no)?
-; WallAbsoluteDestroyer = Does this warhead do killing damage to a wall, instead of one wound?  (def=no) ;gs
-; Wood = Does this warhead damage wood walls (def=no)?
-; Fire = Does this produce great heat and thus will melt ice (def=no)?
-; Radiation = Is this a radiation weapon?  Certains units will be immune to this. (def=no)
-; Tiberium = Does this warhead destroy tiberium (def=no)?
-; Sparky = Does this warhead cause residual flames (def=no)?
-; Conventional = Is explosive warhead big enough to cause a splash when it hits water [nukes are too big for this] (def=no)?
-; Rocker = Can this warhead cause nearby units to rock upon impact (def=no)?
-; AnimList = list of animations to play when warhead explodes [listed from lesser to greater damage]
-; Verses = damage value verses various armor types (as percentage of full damage)...
+; Spread=Obsolete.  Kept entries to give benchmark for new spread system
+; Wall=Does this warhead damage concrete walls (def=no)?
+; WallAbsoluteDestroyer=Does this warhead do killing damage to a wall, instead of one wound?  (def=no) ;gs
+; Wood=Does this warhead damage wood walls (def=no)?
+; Fire=Does this produce great heat and thus will melt ice (def=no)?
+; Radiation=Is this a radiation weapon?  Certains units will be immune to this. (def=no)
+; Tiberium=Does this warhead destroy tiberium (def=no)?
+; Sparky=Does this warhead cause residual flames (def=no)?
+; Conventional=Is explosive warhead big enough to cause a splash when it hits water [nukes are too big for this] (def=no)?
+; Rocker=Can this warhead cause nearby units to rock upon impact (def=no)?
+; AnimList=list of animations to play when warhead explodes [listed from lesser to greater damage]
+; Verses=damage value verses various armor types (as percentage of full damage)...
 ;           -vs- None, Flak, Plate //infantry
 ;				Light, Medium, Heavy //units
 ;				Wood, Steel, Concrete //buildings
@@ -21623,21 +21629,21 @@ ColorSpeed=.13
 ; 5-11 Special_2 is now spawn rockets' armor to keep them from blowing each other up when shot
 ; NOTE: A 0% means that firing is completely illegal.  You can't order it to fire and it won't fire on its own
 ; A 1% means that it will not fire on its own, but it will accept a force fire command
-; InfDeath = which infantry death animation to use (def=0)
+; InfDeath=which infantry death animation to use (def=0)
 ;             0=instant die, 1=twirl die, 2=explodes, 3=flying death, 4=burn death, 5=electro
 ; NEW ONES 6=Yuri head explode 7=Nuke Melt
-; Deform = % chance that this warhead will damage the ground when it hits. (def=0)
-; DeformThreshhold = damage must exceed this amount before deformation can occur (def=0)
-; Particle = Particle effect to use when explosion occurs (def=none)
-; ProneDamage = Damage modifer for infantry when prone (def=1.0)
-; Bright = Does this warhead normally cause a lighting effect when it goes off (def=no). This is overridden in the case of bullets by the weapon 'Bright' flag.
-; CombatLightSize = % of max size; > 0% means force size of combat light, overriding damage-based value (def=0%)
-; Bullets = Is this weapon a bunch of bullet-like gunfire?  (def=no).
-; CellSpread (def 0)= Replaces Spread and WideDamage.  This is actually how far damage from this warhead can spread
+; Deform=% chance that this warhead will damage the ground when it hits. (def=0)
+; DeformThreshhold=damage must exceed this amount before deformation can occur (def=0)
+; Particle=Particle effect to use when explosion occurs (def=none)
+; ProneDamage=Damage modifer for infantry when prone (def=1.0)
+; Bright=Does this warhead normally cause a lighting effect when it goes off (def=no). This is overridden in the case of bullets by the weapon 'Bright' flag.
+; CombatLightSize=% of max size; > 0% means force size of combat light, overriding damage-based value (def=0%)
+; Bullets=Is this weapon a bunch of bullet-like gunfire?  (def=no).
+; CellSpread (def 0)=Replaces Spread and WideDamage.  This is actually how far damage from this warhead can spread
 ;   0 will explicitly only hurt the target, anything higher will at least search some cells around and compare distance
 ; CellInset (def 0)=Use this to tell autodeploy how much inside CellSpread we need to get before autodeploying.
 ;   This way, the desolater won't just blast as soon as the target is on the very edge -- he'll move in a bit.
-; PercentAtMax (def 1.0)= And this is the percent of damage it does at max range; to control fade linearly
+; PercentAtMax (def 1.0)=And this is the percent of damage it does at max range; to control fade linearly
 
 ; EM Pulse cannon warhead.
 [EMPuls];gs disabled in code
@@ -22330,7 +22336,7 @@ AnimList=TSTIMPCT
 
 [ElectricAssault]
 ElectricAssault=yes
-Verses=0%,0,0%,0%,0%,0%,100%,100%,100%,50%,100%
+Verses=0%,0%,0%,0%,0%,0%,100%,100%,100%,50%,100%
 InfDeath=5
 
 [BombDisarm]
@@ -22465,7 +22471,7 @@ Wall=no
 Verses=100%,100%,100%,75%,50%,50%,200%,200%,200%,100%,100%
 AnimList=XGRYSML1,XGRYSML2,EXPLOSML,XGRYMED1,XGRYMED2,EXPLOMED,EXPLOLRG,TWLT070
 
-[MirageWH]	// Supposed to be a heat ray.
+[MirageWH]; Supposed to be a heat ray.
 Verses=100%,100%,80%,100%,100%,100%,30%,20%,20%,100%,100%	; Needs balancing by designers
 AnimList=IRONFX		; temp, should have flash-o-light
 InfDeath=4			; Burn death
@@ -22478,10 +22484,10 @@ CLDisableGreen=true	; This says the Combat Light should be red.  (2)
 ; This section lists all the terrain object types and
 ; specifies their characteristics.
 
-; Immune = Is the terrain immune to combat damage (def=no)?
-; WaterBound = Is the terrain only allowed on the water (def=no)?
-; SpawnsTiberium = Does it spawn growth of Tiberium around it (def=no)?
-; IsFlammable = Can "Forest Fires" spread to and damage this terrain type?
+; Immune=Is the terrain immune to combat damage (def=no)?
+; WaterBound=Is the terrain only allowed on the water (def=no)?
+; SpawnsTiberium=Does it spawn growth of Tiberium around it (def=no)?
+; IsFlammable=Can "Forest Fires" spread to and damage this terrain type?
 
 [BOXES01]
 Name=Boxes
@@ -23020,13 +23026,13 @@ SnowOccupationBits=7
 ; ******* Overlay Objects *******
 ; These are graphic objects that can have an effect on the game.
 
-; Tiberium = Is this tiberium [Tiberium grown and graphic logic applies] (def=no)?
-; Crate = Is this overlay a crate (def=no)?
-; CrateTrigger = Is crate to trigger game events (def=no)?
-; RadarInvisible = Is this overlay not visible on the radar map (def=no)?
-; Explodes = Does it explode violently when destroyed [i.e., does it do collateral damage] (def=no)?
-; LegalTarget = Can it be a legal target for attack (def=no)?
-; ChainReaction = Does it explode and affect adjacent cells (def=no)?
+; Tiberium=Is this tiberium [Tiberium grown and graphic logic applies] (def=no)?
+; Crate=Is this overlay a crate (def=no)?
+; CrateTrigger=Is crate to trigger game events (def=no)?
+; RadarInvisible=Is this overlay not visible on the radar map (def=no)?
+; Explodes=Does it explode violently when destroyed [i.e., does it do collateral damage] (def=no)?
+; LegalTarget=Can it be a legal target for attack (def=no)?
+; ChainReaction=Does it explode and affect adjacent cells (def=no)?
 
 [TIB01]
 Name=Tiberium (Green)
@@ -24024,112 +24030,112 @@ Name=Track NwSe
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS02]
 Name=Track NeSw
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS03]
 Name=Track NS
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS04]
 Name=Track EW
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS05]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS06]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS07]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS08]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS09]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS10]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS11]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS12]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS13]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS14]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS15]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKS16]
 Name=Train Tracks
 Land=Railroad
 LegalTarget=false
 RadarColor=92,92,92
-RadarInvisible = false
+RadarInvisible=false
 
 [TRACKTUNNEL01]
 Name=Train Tracks
@@ -24165,7 +24171,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG02]
 Image=LOBRDG02
@@ -24173,7 +24179,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG03]
 Image=LOBRDG03
@@ -24181,7 +24187,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG04]
 Image=LOBRDG04
@@ -24189,7 +24195,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG05]
 Image=LOBRDG05
@@ -24197,7 +24203,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG06]
 Image=LOBRDG06
@@ -24205,7 +24211,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG07]
 Image=LOBRDG07
@@ -24213,7 +24219,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG08]
 Image=LOBRDG08
@@ -24221,7 +24227,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG09]
 Image=LOBRDG09
@@ -24229,7 +24235,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG10]
 Image=LOBRDG10
@@ -24237,7 +24243,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG11]
 Image=LOBRDG11
@@ -24245,7 +24251,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG12]
 Image=LOBRDG12
@@ -24253,7 +24259,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG13]
 Image=LOBRDG13
@@ -24261,7 +24267,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG14]
 Image=LOBRDG14
@@ -24269,7 +24275,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG15]
 Image=LOBRDG15
@@ -24277,7 +24283,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG16]
 Image=LOBRDG16
@@ -24285,7 +24291,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG17]
 Image=LOBRDG17
@@ -24293,7 +24299,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG18]
 Image=LOBRDG18
@@ -24301,7 +24307,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG19]
 Image=LOBRDG19
@@ -24309,7 +24315,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG20]
 Image=LOBRDG20
@@ -24317,7 +24323,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG21]
 Image=LOBRDG21
@@ -24325,7 +24331,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG22]
 Image=LOBRDG22
@@ -24333,7 +24339,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG23]
 Image=LOBRDG23
@@ -24341,7 +24347,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG24]
 Image=LOBRDG24
@@ -24349,7 +24355,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG25]
 Image=LOBRDG25
@@ -24357,7 +24363,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG26]
 Image=LOBRDG26
@@ -24365,7 +24371,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDG27]
 Image=LOBRDG27
@@ -24373,7 +24379,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=false
-RadarInvisible = true
+RadarInvisible=true
 
 [LOBRDG28]
 Image=LOBRDG28
@@ -24381,7 +24387,7 @@ Name=Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=false
-RadarInvisible = true
+RadarInvisible=true
 
 [LOBRDGE1]
 Image=LOBRDGE1
@@ -24417,7 +24423,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB02]
 Image=LOBRDB02
@@ -24425,7 +24431,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB03]
 Image=LOBRDB03
@@ -24433,7 +24439,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB04]
 Image=LOBRDB04
@@ -24441,7 +24447,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB05]
 Image=LOBRDB05
@@ -24449,7 +24455,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB06]
 Image=LOBRDB06
@@ -24457,7 +24463,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB07]
 Image=LOBRDB07
@@ -24465,7 +24471,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB08]
 Image=LOBRDB08
@@ -24473,7 +24479,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB09]
 Image=LOBRDB09
@@ -24481,7 +24487,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB10]
 Image=LOBRDB10
@@ -24489,7 +24495,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB11]
 Image=LOBRDB11
@@ -24497,7 +24503,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB12]
 Image=LOBRDB12
@@ -24505,7 +24511,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB13]
 Image=LOBRDB13
@@ -24513,7 +24519,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB14]
 Image=LOBRDB14
@@ -24521,7 +24527,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB15]
 Image=LOBRDB15
@@ -24529,7 +24535,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB16]
 Image=LOBRDB16
@@ -24537,7 +24543,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB17]
 Image=LOBRDB17
@@ -24545,7 +24551,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB18]
 Image=LOBRDB18
@@ -24553,7 +24559,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB19]
 Image=LOBRDB19
@@ -24561,7 +24567,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB20]
 Image=LOBRDB20
@@ -24569,7 +24575,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB21]
 Image=LOBRDB21
@@ -24577,7 +24583,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB22]
 Image=LOBRDB22
@@ -24585,7 +24591,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB23]
 Image=LOBRDB23
@@ -24593,7 +24599,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB24]
 Image=LOBRDB24
@@ -24601,7 +24607,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB25]
 Image=LOBRDB25
@@ -24609,7 +24615,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB26]
 Image=LOBRDB26
@@ -24617,7 +24623,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=true
-RadarInvisible = false
+RadarInvisible=false
 
 [LOBRDB27]
 Image=LOBRDB27
@@ -24625,7 +24631,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=false
-RadarInvisible = true
+RadarInvisible=true
 
 [LOBRDB28]
 Image=LOBRDB28
@@ -24633,7 +24639,7 @@ Name=Concrete Low Bridge
 Land=Road
 RadarColor=92,92,92
 NoUseTileLandType=false
-RadarInvisible = true
+RadarInvisible=true
 
 [LOBRDGB1]
 Image=LOBRDGB1
@@ -24688,7 +24694,7 @@ NoUseTileLandType=false
 
 [BRIDGE1]
 Image=BRIDGE
-Name = Bridge 1
+Name=Bridge 1
 LegalTarget=true
 RadarColor=92,92,92
 Overrides=yes
@@ -24696,7 +24702,7 @@ NoUseTileLandType=false
 
 [BRIDGE2]
 Image=BRIDGE
-Name = Bridge 2
+Name=Bridge 2
 LegalTarget=true
 RadarColor=92,92,92
 Overrides=yes
@@ -24704,7 +24710,7 @@ NoUseTileLandType=false
 
 [BRIDGEB1]
 Image=BRIDGB
-Name = Wood Bridge 1
+Name=Wood Bridge 1
 LegalTarget=true
 RadarColor=92,92,92
 Overrides=yes
@@ -24712,7 +24718,7 @@ NoUseTileLandType=false
 
 [BRIDGEB2]
 Image=BRIDGB
-Name = Wood Bridge 2
+Name=Wood Bridge 2
 LegalTarget=true
 RadarColor=92,92,92
 Overrides=yes
@@ -24854,7 +24860,7 @@ Land=Rock
 ; element than a game object) called smudges. These typically
 ; are used to mark the effects of battle.
 
-; Crater = Is this a crater smudge [special growth logic] (def=no)?
+; Crater=Is this a crater smudge [special growth logic] (def=no)?
 [CRATER01]
 Crater=yes
 
@@ -24989,13 +24995,13 @@ Height=2
 ; terrain types. The primary purpose is to differentiate the
 ; movement capabilities.
 
-; Float = % of full speed for ships [0 means impassable] (def=100)
-; Foot = % of full speed for foot soldiers [0 means impassable] (def=100)
-; Track = % of full speed for tracked vehicles [0 means impassable] (def=100)
-; Wheel = % of full speed for wheeled vehicles [0 means impassable] (def=100)
-; Hover = % of full speed for hovering vehicles [0 means impassable] (def=100)
-; Amphibious = % of full speed for amphibious vehicles [0 impassable] (def=100)
-; Buildable = Can buildings be built upon this terrain (def=no)?
+; Float=% of full speed for ships [0 means impassable] (def=100)
+; Foot=% of full speed for foot soldiers [0 means impassable] (def=100)
+; Track=% of full speed for tracked vehicles [0 means impassable] (def=100)
+; Wheel=% of full speed for wheeled vehicles [0 means impassable] (def=100)
+; Hover=% of full speed for hovering vehicles [0 means impassable] (def=100)
+; Amphibious=% of full speed for amphibious vehicles [0 impassable] (def=100)
+; Buildable=Can buildings be built upon this terrain (def=no)?
 
 ; clear grassy terrain
 ;[Clear]
@@ -25195,14 +25201,14 @@ Squad=0,<none>,no                 ; squad of random infantry
 2=Vinifera
 3=Aboreus
 
-; Name = display name
-; Image = image to use [1=small, 2=large, 3=vine]
-; Value = credit value per 'bail'
-; Growth = growth rate
-; Spread = spread rate
-; Power = explosive power per 'bail' (def=0)
-; Color = display color of the Tiberium
-; Shard = crystal to fly off when chain reacting (def=none)
+; Name=display name
+; Image=image to use [1=small, 2=large, 3=vine]
+; Value=credit value per 'bail'
+; Growth=growth rate
+; Spread=spread rate
+; Power=explosive power per 'bail' (def=0)
+; Color=display color of the Tiberium
+; Shard=crystal to fly off when chain reacting (def=none)
 
 ; This is Ore
 [Riparius]
@@ -25263,14 +25269,14 @@ Debris=CRYSTAL1,CRYSTAL2,CRYSTAL3,CRYSTAL4
 ; the program, but there are some behavior characteristics that can
 ; be overridden. Don't modify these.
 
-; NoThreat = Is its weapons disabled and thus ignored as a potential target until fired upon (def=no)?
-; Zombie = Is forced to sit there like a zombie and never recovers (def=no)?
-; Recruitable = Can it be recruited into a team or base defense (def=yes)?
-; Paralyzed = Is the object frozen in place but can still fire and function (def=no)?
-; Retaliate = Is allowed to retaliate while on this mission (def=yes)?
-; Scatter = Is allowed to scatter from threats (def=yes)?
-; Rate = delay between normal processing (larger = faster game, less responsiveness)
-; AARate = anti-aircraft delay rate (if not specifed it uses regular rate).
+; NoThreat=Is its weapons disabled and thus ignored as a potential target until fired upon (def=no)?
+; Zombie=Is forced to sit there like a zombie and never recovers (def=no)?
+; Recruitable=Can it be recruited into a team or base defense (def=yes)?
+; Paralyzed=Is the object frozen in place but can still fire and function (def=no)?
+; Retaliate=Is allowed to retaliate while on this mission (def=yes)?
+; Scatter=Is allowed to scatter from threats (def=yes)?
+; Rate=delay between normal processing (larger=faster game, less responsiveness)
+; AARate=anti-aircraft delay rate (if not specifed it uses regular rate).
 
 ; Unit sits still and plays dead.
 [Sleep]
@@ -25406,31 +25412,31 @@ Rate=.1
 Rate=.016
 
 ; ******* Voxel Debris types *******
-; Translucent = is the debris to be drawn with translucency (def=no)?
-; Elasticity = "bounciness" of the object [should be 0.0 through 1.0] (def=0.75)
-; MinAngularVelocity = minimum rate at which the debris is to spin in degrees (def=0.0)
-; MaxAngularVelocity = maximum rate at which the debris is to spin in degrees (def=10.0)
-; Duration = max number of frames to let the debris exist (def=30)
-; MinZVel = minimum starting Z velocity (def=3.5)
-; MaxZVel = maximum starting Z velocity (def=5.0)
-; MaxXYVel = maximim starting lateral velocity (def=15.0)
-; ShareBodyData = Get the voxel data from another Type's body voxel data (def = no)?
-; ShareTurretData = Get the voxel data from another Type's turret voxel data (def = no)?
-; ShareBarrelData = Get the VOXEL data from another Type's barrel voxel data (def = no)?
-; ShareSource = name of the object to share voxel data from (def = none)
-; VoxelIndex = voxel piece within the voxel data to use (def = 0)
-; StartSound = sound to play when the voxel anim is created (def = VOC_NONE).
-; BounceSound = sound to play when the voxel anim bounces (def = VOC_NONE).
-; ExpireSound = sound to play when the voxel anim expires (def = VOC_NONE).
-; BounceAnim = animation to launch when the voxel anim bounces (def = ANIM_NONE).
-; ExpireAnim = animation to launch when the voxel anim expires (def = ANIM_NONE).
-; TrailerAnim = animation to trail behind the object (usually smoke or flame)
-; DamageRadius = the debris damages objects that it hits if they're closer than this distance
-; Damage = amount of damage to apply to objects that are hit
-; Warhead = warhead to use for damage purposes
-; AttachedSystem = particle system to attach to the voxel anim
-; Spawns = the particle spawned when this voxel debris explodes (def = none)
-; SpawnCount = number of particles spawned [on average] (def = 0)
+; Translucent=is the debris to be drawn with translucency (def=no)?
+; Elasticity="bounciness" of the object [should be 0.0 through 1.0] (def=0.75)
+; MinAngularVelocity=minimum rate at which the debris is to spin in degrees (def=0.0)
+; MaxAngularVelocity=maximum rate at which the debris is to spin in degrees (def=10.0)
+; Duration=max number of frames to let the debris exist (def=30)
+; MinZVel=minimum starting Z velocity (def=3.5)
+; MaxZVel=maximum starting Z velocity (def=5.0)
+; MaxXYVel=maximim starting lateral velocity (def=15.0)
+; ShareBodyData=Get the voxel data from another Type's body voxel data (def=no)?
+; ShareTurretData=Get the voxel data from another Type's turret voxel data (def=no)?
+; ShareBarrelData=Get the VOXEL data from another Type's barrel voxel data (def=no)?
+; ShareSource=name of the object to share voxel data from (def=none)
+; VoxelIndex=voxel piece within the voxel data to use (def=0)
+; StartSound=sound to play when the voxel anim is created (def=VOC_NONE).
+; BounceSound=sound to play when the voxel anim bounces (def=VOC_NONE).
+; ExpireSound=sound to play when the voxel anim expires (def=VOC_NONE).
+; BounceAnim=animation to launch when the voxel anim bounces (def=ANIM_NONE).
+; ExpireAnim=animation to launch when the voxel anim expires (def=ANIM_NONE).
+; TrailerAnim=animation to trail behind the object (usually smoke or flame)
+; DamageRadius=the debris damages objects that it hits if they're closer than this distance
+; Damage=amount of damage to apply to objects that are hit
+; Warhead=warhead to use for damage purposes
+; AttachedSystem=particle system to attach to the voxel anim
+; Spawns=the particle spawned when this voxel debris explodes (def=none)
+; SpawnCount=number of particles spawned [on average] (def=0)
 
 [PIECE]
 Name=Scrap Metal Debris
@@ -25548,7 +25554,7 @@ Duration=70
 ExpireAnim=TWLT070
 Damage=500
 DamageRadius=300
-Warhead=Meteorite
+Warhead=TankOGas; Meteorite - Meteorite doesn't exist. Changed to TankOGas to avoid potential errors. Almost never used.
 IsMeteor=true
 Spawns=PEBBLE
 SpawnCount=5
@@ -25566,7 +25572,7 @@ Duration=70
 ExpireAnim=TWLT100
 Damage=500
 DamageRadius=300
-Warhead=Meteorite
+Warhead=TankOGas; Meteorite - Meteorite doesn't exist. Changed to TankOGas to avoid potential errors. Almost never used.
 IsMeteor=true
 IsTiberium=true
 Spawns=PEBBLE


### PR DESCRIPTION
Normalize formatting across rulesmd.ini: trim extraneous spaces around '=' and comment delimiters, convert some C-style '//' comments to ';', and standardize inline comments. Also comment and relocate duplicate entries (GAWETH_ED/GD) to avoid indexing issues and add a brief note. These are non-functional formatting fixes intended to improve readability and prevent parsing/annotation ambiguity in cncnet.pack and ra2mode.pack rulesmd.ini.

Warhead with missing % value is fixed, structures with comma instead of period for light values have been fixed, CAPOWR added to ra2mode rules. 