### PR TITLE
Add 'Real Time Timers' option and adjust layout

### DIFF
--- a/package/Resources/OptionsWindow.ini
+++ b/package/Resources/OptionsWindow.ini
@@ -27,18 +27,19 @@ SettingKey=AllowTaunts
 5=chkPrioritySelection:SettingCheckBox
 6=chkHarvesterCounter:SettingCheckBox
 7=chkPowerDelta:SettingCheckBox
+8=chkRealTimeTimers:SettingCheckBox
 
 [lblPlayerName]
-Location=12,212
+Location=12,236
 
 [tbPlayerName]
-Location=113,210
+Location=113,234
 
 [btnConfigureHotkeys]
-Location=12,290
+Location=12,314
 
 [lblNotice]
-Location=12,240
+Location=12,264
 
 ; Left Side Toggles
 [chkScrollCoasting]
@@ -81,6 +82,14 @@ ToolTip=Return to main menu immediately after a game is finished.
 DefaultValue=false
 SettingSection=Options
 SettingKey=SkipScoreScreen
+
+[chkRealTimeTimers]
+Location=12,198
+Text=Real Time Timers
+ToolTip=When enabled timers will use real time instead of game time.
+DefaultValue=true
+SettingSection=Phobos
+SettingKey=RealTimeTimers
 
 ; Right Side Toggles
 [chkPrioritySelection]


### PR DESCRIPTION
Introduce a new checkbox option chkRealTimeTimers (SettingKey=RealTimeTimers, SettingSection=Phobos) with DefaultValue=true and tooltip explaining it uses real time instead of game time. Inserted the control into the options index mapping and added its [chkRealTimeTimers] section. Shifted several existing UI element positions (lblPlayerName, tbPlayerName, btnConfigureHotkeys, lblNotice) down to make room for the new control.