### PR TITLE
Replace the default spy disguise from INIT to E2 in RA2

### DIFF
--- a/game-assets/ra2mode.pack/rulesmd.ini
+++ b/game-assets/ra2mode.pack/rulesmd.ini
@@ -270,7 +270,8 @@ SovParaDropNum=9 ;How many of each of those infantry
 
 ;*** Spy stuff ***
 AlliedDisguise=E1
-SovietDisguise=E2 ; these are the defaults for the spy if a MakeupKit hasn't been used
+SovietDisguise=E2 ; CCCP84: 04.2026 In Yuri's Revenge engine, this is no longer the default
+ThirdDisguise=E2 ; CCCP84: 04.2026 This used by default. In RA2 avoid using Yuri's units as camouflage, this may cause error
 SpyPowerBlackout=1000 ; Frame time a spy shuts down power for (900 = 1 minute)
 SpyMoneyStealPercent=.5 ; Percent of total money you take with a spy
 AttackCursorOnDisguise=no ;gs If yes, the mouse will be an attack cursor on a disguised unit as if he is not disguised.


### PR DESCRIPTION
Fixes #875
