### PR TITLE
Update `@actions/github` and Migrate `tools/*` to ESM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@
 /package/VersionWriter.exe
 
 .idea/*
+.vscode/*
 /CnCNet5_YR_Installer.exe
 /gitversion.json
 /logs

--- a/tools/build-installer/class/template-app-model.class.ts
+++ b/tools/build-installer/class/template-app-model.class.ts
@@ -1,9 +1,9 @@
 export class TemplateAppModel {
-    name: string;
-    version: string;
-    versionName: string;
-    publisher: string;
-    publisherUrl: string;
-    supportUrl: string;
-    updatesUrl: string;
+    name!: string;
+    version!: string;
+    versionName!: string;
+    publisher!: string;
+    publisherUrl!: string;
+    supportUrl!: string;
+    updatesUrl!: string;
 }

--- a/tools/build-installer/class/template-model.class.ts
+++ b/tools/build-installer/class/template-model.class.ts
@@ -1,12 +1,12 @@
 import { TemplateAppModel } from './template-app-model.class';
 
 export class TemplateModel {
-    app: TemplateAppModel;
-    sourceDir: string;
-    outputDir: string;
-    setupIconFile: string;
-    licenseFile: string;
-    outputBaseFilename: string;
-    installDeleteFiles: string[];
-    excludedInstallerFiles: string;
+    app!: TemplateAppModel;
+    sourceDir!: string;
+    outputDir!: string;
+    setupIconFile!: string;
+    licenseFile!: string;
+    outputBaseFilename!: string;
+    installDeleteFiles!: string[];
+    excludedInstallerFiles!: string;
 }

--- a/tools/build-installer/constants.ts
+++ b/tools/build-installer/constants.ts
@@ -1,23 +1,25 @@
-import { resolve } from 'path';
+import * as path from 'path';
+import * as url from 'url';
 
 export function createConstants(workingDir: string) {
-    const packagePath = resolve(workingDir);
-    const repoPath = resolve(packagePath, '..');
-    const versionFilePath = resolve(packagePath, 'version');
-    const innoPath = resolve(__dirname, 'inno');
-    const innoResourcesPath = resolve(innoPath, 'Resources');
-    const innoBinPath = resolve(innoPath, 'bin');
-    const dependencyInstallerPath = resolve(innoPath, 'libs/InnoDependencyInstaller/CodeDependencies.iss');
-    const setupIconPath = resolve(innoResourcesPath, 'cncnet5.ico');
-    const licenseFilePath = resolve(innoResourcesPath, 'License-YurisRevenge.txt');
-    const installerBinary = resolve(innoBinPath, 'ISCC.exe');
-    const installerTemplate = resolve(innoPath, 'installer.twig');
-    const installerScript = resolve(innoPath, 'installer.iss');
-    const winePrefixPath = resolve(__dirname, '.wine');
+    const currentDir = path.dirname(url.fileURLToPath(import.meta.url));
+    const packagePath = path.resolve(workingDir);
+    const repoPath = path.resolve(packagePath, '..');
+    const versionFilePath = path.resolve(packagePath, 'version');
+    const innoPath = path.resolve(currentDir, 'inno');
+    const innoResourcesPath = path.resolve(innoPath, 'Resources');
+    const innoBinPath = path.resolve(innoPath, 'bin');
+    const dependencyInstallerPath = path.resolve(innoPath, 'libs/InnoDependencyInstaller/CodeDependencies.iss');
+    const setupIconPath = path.resolve(innoResourcesPath, 'cncnet5.ico');
+    const licenseFilePath = path.resolve(innoResourcesPath, 'License-YurisRevenge.txt');
+    const installerBinary = path.resolve(innoBinPath, 'ISCC.exe');
+    const installerTemplate = path.resolve(innoPath, 'installer.twig');
+    const installerScript = path.resolve(innoPath, 'installer.iss');
+    const winePrefixPath = path.resolve(currentDir, '.wine');
     const preUpdateExecFilename = 'preupdateexec';
     const updateExecFilename = 'updateexec';
-    const preUpdateExecFilePath = resolve(packagePath, preUpdateExecFilename);
-    const updateExecFilePath = resolve(packagePath, updateExecFilename);
+    const preUpdateExecFilePath = path.resolve(packagePath, preUpdateExecFilename);
+    const updateExecFilePath = path.resolve(packagePath, updateExecFilename);
 
     return {
         app: {
@@ -49,5 +51,3 @@ export function createConstants(workingDir: string) {
         excludedInstallerFiles: [preUpdateExecFilename, updateExecFilename, 'versionconfig.ini', 'RA2MD.ini'],
     };
 }
-
-export type BuildInstallerConstants = ReturnType<typeof createConstants>;

--- a/tools/build-installer/package.json
+++ b/tools/build-installer/package.json
@@ -2,17 +2,19 @@
   "name": "build-installer",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "main": "./index.ts",
   "scripts": {
     "start": "tsx index.ts"
   },
   "dependencies": {
-    "tsx": "^4.21.0",
     "js-ini": "^1.6.0",
+    "tsx": "^4.21.0",
     "twig": "^3.0.0"
   },
   "devDependencies": {
     "@types/node": "^24.12.2",
+    "@types/twig": "^1.12.17",
     "typescript": "^6.0.2"
   }
 }

--- a/tools/build-installer/service/build-installer.service.ts
+++ b/tools/build-installer/service/build-installer.service.ts
@@ -1,23 +1,28 @@
-import { spawn } from 'child_process';
-import { BuildInstallerConstants, createConstants } from 'build-installer/constants';
-import * as Twig from 'twig';
-import { access, readFile, writeFile } from 'fs';
-import { mkdir } from 'fs/promises';
-import { TemplateModel } from 'build-installer/class/template-model.class';
-import { parse as parseIni } from 'js-ini';
 import { parseArgs } from 'util';
-import * as util from 'util';
-import { resolve } from 'path';
+import * as childProcess from 'child_process';
+import * as fs from 'fs';
+import * as fsPromises from 'fs/promises';
+import * as path from 'path';
 
-interface BuildCommandOptions {
+import { parse as parseIni, type IIniObjectSection } from 'js-ini';
+import Twig from 'twig';
+
+import { createConstants } from 'build-installer/constants';
+import { type TemplateModel } from 'build-installer/class/template-model.class';
+
+interface IBuildCommandOptions {
     command: string;
     args: string[];
     env?: NodeJS.ProcessEnv;
     useWindowsPaths: boolean;
 }
 
+function isIniSection(value: unknown): value is IIniObjectSection {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 export class BuildInstallerService {
-    private constants: BuildInstallerConstants;
+    private constants: ReturnType<typeof createConstants>;
 
     public constructor(private workingDir: string) {
         this.constants = createConstants(workingDir);
@@ -58,7 +63,7 @@ export class BuildInstallerService {
             Twig.renderFile(this.constants.paths.installerTemplate, templateModel, (err, content) => {
                 if (err) throw err;
 
-                writeFile(this.constants.paths.installerScript, content, (err) => {
+                fs.writeFile(this.constants.paths.installerScript, content, (err) => {
                     if (err) throw err;
 
                     console.log(`Installer script written to '${this.constants.paths.installerScript}'`);
@@ -92,13 +97,22 @@ export class BuildInstallerService {
     }
 
     private async getAppVersion(): Promise<string> {
-        const versionContent = await util.promisify(readFile)(this.constants.paths.versionFilePath, {
+        const versionContent = await fsPromises.readFile(this.constants.paths.versionFilePath, {
             encoding: 'utf-8',
         });
+
         const versionIni = parseIni(versionContent, {
             autoTyping: false,
         });
-        return versionIni['DTA']['Version'];
+
+        const dtaSection = versionIni['DTA'];
+
+        if (!isIniSection(dtaSection)) {
+            return 'undefined';
+        }
+
+        const version = dtaSection['Version'];
+        return typeof version === 'string' ? version : 'undefined';
     }
 
     private async getInstallDeleteFiles(): Promise<string[]> {
@@ -116,7 +130,7 @@ export class BuildInstallerService {
     }
 
     private async getUpdateExecFileEntries(file: string): Promise<string[]> {
-        const content = await util.promisify(readFile)(file, { encoding: 'utf-8' });
+        const content = await fsPromises.readFile(file, { encoding: 'utf-8' });
         const ini = parseIni(content, {
             autoTyping: false,
             // tell the parser to read this as a list of strings without keys
@@ -130,10 +144,10 @@ export class BuildInstallerService {
             .filter(this.isValidDeleteEntry)
             .filter(async (entry) => {
                 try {
-                    const entryPath = resolve(this.constants.paths.packagePath, entry);
+                    const entryPath = path.resolve(this.constants.paths.packagePath, entry);
                     // if this succeeds, then the file or dir currently exists in /package dir
                     // it probably shouldn't exist in preupdateexec or updateexec files
-                    await util.promisify(access)(entryPath);
+                    await fsPromises.access(entryPath);
                     console.warn(`File in '${file}' delete list, but still in repo: '${entryPath}'`);
                     return false;
                 } catch (e) {
@@ -143,7 +157,7 @@ export class BuildInstallerService {
     }
 
     private isValidDeleteEntry(entry: string): boolean {
-        return entry && entry !== 'do_not_remove_this_line';
+        return Boolean(entry && entry !== 'do_not_remove_this_line');
     }
 
     private async checkForRequiredFilesAsync(): Promise<void> {
@@ -161,7 +175,7 @@ export class BuildInstallerService {
 
     private async checkForRequiredFileAsync(filePath: string): Promise<void> {
         try {
-            await util.promisify(access)(filePath);
+            await fsPromises.access(filePath);
         } catch (error) {
             if (filePath === this.constants.paths.dependencyInstallerPath) {
                 throw new Error(
@@ -174,7 +188,7 @@ export class BuildInstallerService {
         }
     }
 
-    private async getBuildCommandOptions(): Promise<BuildCommandOptions> {
+    private async getBuildCommandOptions(): Promise<IBuildCommandOptions> {
         if (process.platform === 'win32') {
             return {
                 command: this.constants.paths.installerBinary,
@@ -190,12 +204,12 @@ export class BuildInstallerService {
         throw new Error(`Unsupported platform for build-installer: ${process.platform}`);
     }
 
-    private async getLinuxBuildCommandOptions(): Promise<BuildCommandOptions> {
+    private async getLinuxBuildCommandOptions(): Promise<IBuildCommandOptions> {
         if (!(await this.isCommandAvailable(this.constants.commands.wine, ['--version']))) {
             throw new Error('build-installer requires wine on Linux, but it was not found in PATH.');
         }
 
-        await mkdir(this.constants.paths.winePrefixPath, { recursive: true });
+        await fsPromises.mkdir(this.constants.paths.winePrefixPath, { recursive: true });
         console.log(`Running ISCC.exe via wine with local prefix '${this.constants.paths.winePrefixPath}'`);
 
         return {
@@ -215,7 +229,7 @@ export class BuildInstallerService {
 
     private async isCommandAvailable(command: string, args: string[]): Promise<boolean> {
         return await new Promise((resolvePromise) => {
-            const child = spawn(command, args, {
+            const child = childProcess.spawn(command, args, {
                 stdio: 'ignore',
             });
 
@@ -234,10 +248,10 @@ export class BuildInstallerService {
         });
     }
 
-    private async buildInstaller(commandOptions: BuildCommandOptions): Promise<void> {
+    private async buildInstaller(commandOptions: IBuildCommandOptions): Promise<void> {
         console.log(`Building installer from script '${this.constants.paths.installerScript}'`);
         await new Promise<void>((resolvePromise, reject) => {
-            const inno = spawn(commandOptions.command, commandOptions.args, {
+            const inno = childProcess.spawn(commandOptions.command, commandOptions.args, {
                 cwd: this.constants.paths.innoBinPath,
                 env: commandOptions.env,
             });

--- a/tools/core/class/abstract-option-values.class.ts
+++ b/tools/core/class/abstract-option-values.class.ts
@@ -1,5 +1,5 @@
-﻿import { OptionValues } from 'commander';
+﻿import { type OptionValues } from 'commander';
 
 export class AbstractOptionValues implements OptionValues {
-    token?: string;
+    token!: string;
 }

--- a/tools/core/class/publish-release-option-values.class.ts
+++ b/tools/core/class/publish-release-option-values.class.ts
@@ -1,19 +1,20 @@
-import { AbstractOptionValues } from './abstract-option-values.class';
 import { Command } from 'commander';
 
+import { AbstractOptionValues } from './abstract-option-values.class';
+
 export class PublishReleaseOptionValues extends AbstractOptionValues {
-    sshHost: string;
-    sshPort: number;
-    sshUsername: string;
-    sshKeyBase64: string;
-    sshPassphrase: string;
-    yrGamePath: string;
-    ircServer: string;
-    ircChannel: string;
-    ircNick: string;
-    ircUserName: string;
-    ircPassword: string;
-    ircRealName: string;
+    sshHost!: string;
+    sshPort!: number;
+    sshUsername!: string;
+    sshKeyBase64!: string;
+    sshPassphrase!: string;
+    yrGamePath!: string;
+    ircServer!: string;
+    ircChannel!: string;
+    ircNick!: string;
+    ircUserName!: string;
+    ircPassword!: string;
+    ircRealName!: string;
 
     static parse(): PublishReleaseOptionValues {
         return new Command()

--- a/tools/core/class/release-asset-uploader-option-values.class.ts
+++ b/tools/core/class/release-asset-uploader-option-values.class.ts
@@ -2,8 +2,8 @@
 import { Command } from 'commander';
 
 export class ReleaseAssetUploaderOptionValues extends AbstractOptionValues {
-    assetPath: string;
-    assetName: string;
+    assetPath!: string;
+    assetName!: string;
 
     static parse(): ReleaseAssetUploaderOptionValues {
         return new Command()

--- a/tools/core/constants.ts
+++ b/tools/core/constants.ts
@@ -1,12 +1,15 @@
-import { resolve } from 'path';
+import * as path from 'path';
+import * as url from 'url';
 
-const rootPath = resolve(__dirname, '../../');
-const toolsPath = resolve(rootPath, 'tools');
-const packagePath = resolve(rootPath, 'package');
-const mapsPath = resolve(packagePath, 'Maps');
-const yrMapsPath = resolve(mapsPath, `Yuri's Revenge`);
-const iniPath = resolve(packagePath, 'INI');
-const mpMapsIniPath = resolve(iniPath, 'MPMaps.ini');
+const currentDir = path.dirname(url.fileURLToPath(import.meta.url));
+const rootPath = path.resolve(currentDir, '../../');
+const toolsPath = path.resolve(rootPath, 'tools');
+const packagePath = path.resolve(rootPath, 'package');
+const mapsPath = path.resolve(packagePath, 'Maps');
+const yrMapsPath = path.resolve(mapsPath, `Yuri's Revenge`);
+const iniPath = path.resolve(packagePath, 'INI');
+const mpMapsIniPath = path.resolve(iniPath, 'MPMaps.ini');
+
 export const coreConstants = {
     paths: {
         // the root of the repo

--- a/tools/core/interface/irc-server-config.interface.ts
+++ b/tools/core/interface/irc-server-config.interface.ts
@@ -1,4 +1,4 @@
-export class IrcServerConfig {
+export interface IIrcServerConfig {
     server: string;
     nick: string;
     userName: string;

--- a/tools/core/interface/ssh-config.interface.ts
+++ b/tools/core/interface/ssh-config.interface.ts
@@ -1,4 +1,4 @@
-export class SshConfig {
+export interface ISshConfig {
     host: string;
     port: number;
     username: string;

--- a/tools/core/package.json
+++ b/tools/core/package.json
@@ -2,9 +2,10 @@
   "name": "cncnet-core",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "dependencies": {
     "tsx": "^4.21.0",
-    "@actions/github": "^6.0.1",
+    "@actions/github": "^9.1.0",
     "commander": "^12.1.0",
     "irc": "^0.5.2",
     "ssh2": "^1.17.0"

--- a/tools/core/service/abstract-repo.service.ts
+++ b/tools/core/service/abstract-repo.service.ts
@@ -1,18 +1,17 @@
-﻿import { GitHub } from '@actions/github/lib/utils';
 import { getOctokit } from '@actions/github';
+
 import { AbstractOptionValues } from 'cncnet-core/class/abstract-option-values.class';
 
 const TAG_REGEX: RegExp = /^refs\/tags\/(yr-\d+.\d+(?:\.\d+){0,1})$/;
 
 export abstract class AbstractRepoService<T extends AbstractOptionValues> {
-    protected github?: InstanceType<typeof GitHub>;
+    protected github?: ReturnType<typeof getOctokit>;
 
     protected optionValues: T;
 
     public constructor() {
         this.optionValues = this.getOptionValues();
         if (this.optionValues.token) {
-            // this lib isn't always necessary
             this.github = getOctokit(this.optionValues.token);
         }
     }

--- a/tools/core/service/irc-client.service.ts
+++ b/tools/core/service/irc-client.service.ts
@@ -1,5 +1,6 @@
-import { Client } from 'irc';
-import { IrcServerConfig } from 'cncnet-core/class/irc-server-config.class';
+import { Client, type IMessage } from 'irc';
+
+import { type IIrcServerConfig } from 'cncnet-core/interface/irc-server-config.interface';
 
 const timeout = 60000; // 1 minute
 /**
@@ -9,13 +10,12 @@ export class IrcClientService {
     private client: Client;
 
     /**
-     *
-     * @param config
+     * @param config the IRC server connection settings
      * @param channel the channel to post this update message to
      * @param releaseVersion the release version to include in the update message
      */
     public constructor(
-        private config: IrcServerConfig,
+        private config: IIrcServerConfig,
         private channel: string,
         private releaseVersion: string,
     ) {
@@ -65,7 +65,7 @@ export class IrcClientService {
      * @private
      */
     private async waitForAuthNotice(): Promise<void> {
-        const messageHandler = async (message: string) => {
+        const messageHandler = async (message: IMessage) => {
             if (await this.isAuthorizedMessage(message)) {
                 this.client.removeListener('raw', messageHandler);
                 console.log('Authorized.');
@@ -79,7 +79,7 @@ export class IrcClientService {
         this.client.addListener('raw', messageHandler.bind(this));
     }
 
-    private async isAuthorizedMessage(message: any): Promise<boolean> {
+    private async isAuthorizedMessage(message: IMessage): Promise<boolean> {
         return (
             message.command === 'NOTICE' &&
             message.args.length > 1 &&
@@ -88,7 +88,7 @@ export class IrcClientService {
         );
     }
 
-    private async isIncorrectPasswordMessage(message: any): Promise<boolean> {
+    private async isIncorrectPasswordMessage(message: IMessage): Promise<boolean> {
         return (
             message.command === 'NOTICE' &&
             message.args.length > 1 &&
@@ -116,9 +116,9 @@ export class IrcClientService {
     private async sendUpdateMessage(): Promise<void> {
         const updateMessage = `UPDATE ${this.releaseVersion}`;
         console.log(`Sending update message: ${updateMessage}...`);
-        this.client.ctcp(this.channel, null, updateMessage);
+        this.client.ctcp(this.channel, 'notice', updateMessage);
         console.log('Disconnecting...');
-        this.client.disconnect();
+        this.client.disconnect('Closing session', () => undefined);
         process.exit(0);
     }
 

--- a/tools/core/service/ssh-client.service.ts
+++ b/tools/core/service/ssh-client.service.ts
@@ -1,8 +1,9 @@
-import { Client } from 'ssh2';
-import { SshConfig } from 'cncnet-core/class/ssh-config.class';
+import { Client, type ClientChannel } from 'ssh2';
+
+import { type ISshConfig } from 'cncnet-core/interface/ssh-config.interface';
 
 export class SshClientService {
-    constructor(private sshConfig: SshConfig) {}
+    constructor(private sshConfig: ISshConfig) {}
 
     public async executeCommands(commands: string[]): Promise<void> {
         const conn = new Client();
@@ -15,7 +16,7 @@ export class SshClientService {
                     .on('close', () => {
                         conn.end();
                     })
-                    .on('data', (data) => {
+                    .on('data', (_data: Buffer | string) => {
                         // only uncomment for debugging purposes
                         // console.log(data.toString());
                     });

--- a/tools/map-name-case-fix/package.json
+++ b/tools/map-name-case-fix/package.json
@@ -2,6 +2,7 @@
   "name": "map-name-case-fix",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "main": "./index.ts",
   "scripts": {
     "start": "tsx index.ts"

--- a/tools/map-name-case-fix/service/map-name-case-fix.service.ts
+++ b/tools/map-name-case-fix/service/map-name-case-fix.service.ts
@@ -1,18 +1,17 @@
-import { MpMapsFileService } from 'mpmaps-updater/class/mp-maps-file.service';
-import * as path from 'path';
-import { readdirSync } from 'fs';
-import * as fs from 'fs';
 import { parseArgs } from 'util';
+import * as fs from 'fs';
+import * as path from 'path';
 
-interface MapKeyPairing {
+import { MpMapsFileService } from 'mpmaps-updater/class/mp-maps-file.service';
+interface IMapKeyPairing {
     mapKey: string;
     imageName: string;
 }
 
 export class MapNameCaseFixService {
     private mpMapsFileService: MpMapsFileService;
-    private mapDirectoryFiles: string[];
-    private mapDirectoryFilesLower: string[];
+    private mapDirectoryFiles: string[] = [];
+    private mapDirectoryFilesLower: string[] = [];
     private yrMapsPath: string;
 
     public constructor(private workingDir: string) {
@@ -44,7 +43,7 @@ export class MapNameCaseFixService {
         // scan MPMaps.ini file for eligible maps
         // compare keys found in MPMaps.ini to filenames for *.map and *.png files
         await this.loadMapDirectoryFilesAsync();
-        const invalidMapPairings: MapKeyPairing[] = (await this.mpMapsFileService.getMapKeysAsync())
+        const invalidMapPairings: IMapKeyPairing[] = (await this.mpMapsFileService.getMapKeysAsync())
             .map((mapKey) => this.getInvalidMapPairing(mapKey))
             .filter((pairing) => !!pairing);
 
@@ -52,7 +51,7 @@ export class MapNameCaseFixService {
         console.log(`processed ${invalidMapPairings.length} invalid map(s)`);
     }
 
-    private fixInvalidMapKey(mapKeyPairing: MapKeyPairing): void {
+    private fixInvalidMapKey(mapKeyPairing: IMapKeyPairing): void {
         const mapFilePreviewImg = this.getMapKeyImagePath(mapKeyPairing.mapKey);
 
         const oldName = mapKeyPairing.imageName;
@@ -68,9 +67,9 @@ export class MapNameCaseFixService {
         this.mapDirectoryFilesLower = this.mapDirectoryFiles.map((f) => f.toLowerCase());
     }
 
-    private async readDirAsync(filePath: string): Promise<string[]> {
-        const files = [];
-        readdirSync(filePath, { withFileTypes: true }).map(async (f) => {
+    private async readDirAsync(filePath: string): Promise<Array<string>> {
+        const files: Array<string> = [];
+        fs.readdirSync(filePath, { withFileTypes: true }).map(async (f) => {
             if (f.isFile()) {
                 files.push(path.join(filePath, f.name));
                 return;
@@ -82,7 +81,7 @@ export class MapNameCaseFixService {
         return files;
     }
 
-    private getInvalidMapPairing(mapKey: string): MapKeyPairing {
+    private getInvalidMapPairing(mapKey: string): IMapKeyPairing | null {
         const mapFilePreviewImg = this.getMapKeyImagePath(mapKey);
         const fileLowerIndex = this.mapDirectoryFilesLower.indexOf(mapFilePreviewImg.toLowerCase());
 

--- a/tools/mix-packer/ExFS.ts
+++ b/tools/mix-packer/ExFS.ts
@@ -1,7 +1,8 @@
-import * as fs from 'fs-extra';
 import * as path from 'path';
+
+import fastFolderSizeSync from 'fast-folder-size/sync';
+import fs from 'fs-extra';
 import * as glob from 'glob';
-const fastFolderSizeSync = require('fast-folder-size/sync') as (target: string) => number;
 
 function toPosixPath(pathStr: string) {
     return pathStr.replace(/\\/g, '/');

--- a/tools/mix-packer/MIXFile.ts
+++ b/tools/mix-packer/MIXFile.ts
@@ -1,8 +1,9 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
 import CRC32 from './CRC32';
 import ExBuffer from './ExBuffer';
 import ExFS from './ExFS';
-import * as path from 'path';
-import * as fs from 'fs';
 
 export default class MIXFile {
     folderPath: string;

--- a/tools/mix-packer/index.ts
+++ b/tools/mix-packer/index.ts
@@ -1,7 +1,8 @@
-import MIXFile from './MIXFile';
-import ExFS from './ExFS';
-import * as path from 'path';
 import { parseArgs } from 'util';
+import * as path from 'path';
+
+import ExFS from './ExFS';
+import MIXFile from './MIXFile';
 
 function getOptions() {
     const { values } = parseArgs({

--- a/tools/mix-packer/package.json
+++ b/tools/mix-packer/package.json
@@ -2,6 +2,7 @@
   "name": "mix-packer",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "main": "index.ts",
   "scripts": {
     "start": "tsx index.ts"

--- a/tools/mpmaps-updater/class/ini-file.class.ts
+++ b/tools/mpmaps-updater/class/ini-file.class.ts
@@ -1,7 +1,12 @@
-import { parse } from 'path';
-import { IIniObject, IniValue, parse as parseIni, stringify as stringifyIni } from 'js-ini';
-import * as util from 'util';
-import { readFile, writeFile } from 'fs';
+import * as fsPromises from 'fs/promises';
+import * as path from 'path';
+
+import { parse as parseIni, stringify as stringifyIni } from 'js-ini';
+import type { IIniObject, IIniObjectSection, IniValue } from 'js-ini';
+
+function isIniSection(value: unknown): value is IIniObjectSection {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
 
 export class IniFile {
     protected filePath: string;
@@ -11,7 +16,7 @@ export class IniFile {
     public data: IIniObject;
 
     private constructor(filePath: string, data: IIniObject, packagePath: string) {
-        const parsed = parse(filePath);
+        const parsed = path.parse(filePath);
         this.filePath = filePath;
         this.fileName = parsed.name;
         this.fileExt = parsed.ext;
@@ -32,15 +37,15 @@ export class IniFile {
      * Write this file to disk.
      */
     public async writeAsync(): Promise<void> {
-        await util.promisify(writeFile)(this.filePath, (await this.stringify()).trim());
+        await fsPromises.writeFile(this.filePath, (await this.stringify()).trim());
     }
 
     /**
      * Create an instance of this file.
-     * @param {string} filePath the path at which this file should be read from or written to
+     * @param filePath the path at which this file should be read from or written to
      */
     public static async createAsync(filePath: string, packagePath: string): Promise<IniFile> {
-        const content = await util.promisify(readFile)(filePath, {
+        const content = await fsPromises.readFile(filePath, {
             encoding: 'utf-8',
         });
         const iniObject = parseIni(content, {
@@ -52,8 +57,8 @@ export class IniFile {
     /**
      * Adds/sets the map section to the file, by header
      * Example: [Maps\Yuri's Revenge\hillbtwn]
-     * @param {string} mpMapKey The key to write, ex: Maps\Yuri's Revenge\hillbtwn
-     * @param {IniValue} iniValue The object to write
+     * @param mpMapKey The key to write, ex: Maps\Yuri's Revenge\hillbtwn
+     * @param iniValue The object to write
      */
     public setMapSection(mpMapKey: string, iniValue: IniValue): void {
         this.data[mpMapKey] = iniValue;
@@ -61,7 +66,6 @@ export class IniFile {
 
     /**
      * Deletes a map section the MPMaps.ini file. This would be done when a map has been removed from the repo.
-     * @param {string} mpMapKey
      */
     public deleteMapSection(mpMapKey: string): void {
         delete this.data[mpMapKey];
@@ -69,7 +73,7 @@ export class IniFile {
 
     /**
      * Sets the object of the entire [MultiMaps] section
-     * @param {IniValue} iniValue
+     * @param iniValue The object to write to the [MultiMaps] section.
      */
     public setMultiMapsSection(iniValue: IniValue): void {
         this.data['MultiMaps'] = iniValue;
@@ -77,7 +81,6 @@ export class IniFile {
 
     /**
      * Get the object at the [MultiMaps] section.
-     * @return {IniValue}
      */
     public getMultiMapsSection(): IniValue {
         return this.getSection('MultiMaps');
@@ -85,8 +88,6 @@ export class IniFile {
 
     /**
      * Gets the [Basic] section of the file. This is most commonly used for .map files.
-     *
-     * @return {IniValue}
      */
     public getBasicSection(): IniValue {
         return this.getSection('Basic');
@@ -94,8 +95,6 @@ export class IniFile {
 
     /**
      * Gets the [Header] section of the file. This is most commonly used for .map files.
-     *
-     * @return {IniValue}
      */
     public getHeaderSection(): IniValue {
         return this.getSection('Header');
@@ -103,8 +102,7 @@ export class IniFile {
 
     /**
      * Get any data section by name
-     * @param {string} sectionName
-     * @return {IniValue}
+     * @param sectionName the name of the section to retrieve
      */
     public getSection(sectionName: string): IniValue {
         return this.data[sectionName];
@@ -112,22 +110,22 @@ export class IniFile {
 
     /**
      * Gets the [Waypoints] section of the file. This is most commonly used for .map files.
-     * @return {IniValue}
      */
     public getWaypointsSection(): IniValue {
         return this.getSection('Waypoints');
     }
 
-    /**
-     * @return {string[]}
-     */
     public getWaypointsSectionValues(): string[] {
-        return Object.values(this.getWaypointsSection());
+        const section = this.getWaypointsSection();
+        if (!isIniSection(section)) {
+            return [];
+        }
+
+        return Object.values(section).filter((value): value is string => typeof value === 'string');
     }
 
     /**
      * Gets the [Map] section of the file. This is most commonly used for .map files.
-     * @return {IniValue}
      */
     public getMapSection(): IniValue {
         return this.getSection('Map');
@@ -135,24 +133,24 @@ export class IniFile {
 
     /**
      * Gets the values of each key in the [MultiMaps] section
-     * @return {string[]}
      */
     public getMultiMapsValues(): string[] {
-        return Object.values(this.getMultiMapsSection());
+        const section = this.getMultiMapsSection();
+        if (!isIniSection(section)) {
+            return [];
+        }
+
+        return Object.values(section).filter((value): value is string => typeof value === 'string');
     }
 
     /**
      * Can be used to generate the key used for a given map.
      * Example: Maps\Yuri's Revenge\hillbtwn
-     * @return {string}
      */
     public getMpMapsKey(): string {
         return this.normalizeMpMapsPath(this.filePath.slice(this.packagePath.length + 1, -this.fileExt.length));
     }
 
-    /**
-     * @return {string}
-     */
     public getPackageRelativePath(): string {
         return this.filePath.slice(this.packagePath.length + 1);
     }

--- a/tools/mpmaps-updater/class/mp-maps-file.service.ts
+++ b/tools/mpmaps-updater/class/mp-maps-file.service.ts
@@ -1,10 +1,11 @@
-import { join } from 'path';
+import * as path from 'path';
+
 import { IniFile } from './ini-file.class';
 
 export class MpMapsFileService {
     public constructor(
         private packagePath: string,
-        private mpMapsIniPath: string = join(packagePath, 'INI', 'MPMaps.ini'),
+        private mpMapsIniPath: string = path.join(packagePath, 'INI', 'MPMaps.ini'),
     ) {}
 
     public async getMpMapsIniFileAsync(): Promise<IniFile> {

--- a/tools/mpmaps-updater/constants.ts
+++ b/tools/mpmaps-updater/constants.ts
@@ -1,12 +1,12 @@
-import { resolve } from 'path';
+import * as path from 'path';
 
 export function createConstants(workingDir: string) {
-    const packagePath = resolve(workingDir);
-    const mapsPath = resolve(packagePath, 'Maps');
-    const yrMapsPath = resolve(mapsPath, `Yuri's Revenge`);
-    const iniPath = resolve(packagePath, 'INI');
-    const mpMapsIniPath = resolve(iniPath, 'MPMaps.ini');
-    const updateExecPath = resolve(packagePath, 'updateexec');
+    const packagePath = path.resolve(workingDir);
+    const mapsPath = path.resolve(packagePath, 'Maps');
+    const yrMapsPath = path.resolve(mapsPath, `Yuri's Revenge`);
+    const iniPath = path.resolve(packagePath, 'INI');
+    const mpMapsIniPath = path.resolve(iniPath, 'MPMaps.ini');
+    const updateExecPath = path.resolve(packagePath, 'updateexec');
 
     return {
         regex: {
@@ -46,5 +46,3 @@ export function createConstants(workingDir: string) {
         },
     };
 }
-
-export type MpMapsUpdaterConstants = ReturnType<typeof createConstants>;

--- a/tools/mpmaps-updater/interface/sorted-map-section.interface.ts
+++ b/tools/mpmaps-updater/interface/sorted-map-section.interface.ts
@@ -1,6 +1,6 @@
-import { IniValue } from 'js-ini';
+import { type IIniObjectSection } from 'js-ini';
 
-export interface SortedMapSection {
+export interface ISortedMapSection {
     mapKey: string;
-    section: IniValue;
+    section: IIniObjectSection;
 }

--- a/tools/mpmaps-updater/package.json
+++ b/tools/mpmaps-updater/package.json
@@ -2,6 +2,7 @@
   "name": "mpmaps-updater",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "main": "./index.ts",
   "scripts": {
     "start": "tsx index.ts"

--- a/tools/mpmaps-updater/service/map-loader.service.ts
+++ b/tools/mpmaps-updater/service/map-loader.service.ts
@@ -1,7 +1,7 @@
-import { readdir, stat } from 'fs';
-import * as util from 'util';
-import { IniFile } from 'mpmaps-updater/class/ini-file.class';
+import * as fsPromises from 'fs/promises';
 import * as path from 'path';
+
+import { IniFile } from 'mpmaps-updater/class/ini-file.class';
 
 export class MapLoaderService {
     public constructor(
@@ -16,13 +16,13 @@ export class MapLoaderService {
 
     private async getMapFilesFromDirAsync(dir: string): Promise<IniFile[]> {
         const maps: IniFile[] = [];
-        const dirFiles: string[] = await util.promisify(readdir)(dir, {
+        const dirFiles: string[] = await fsPromises.readdir(dir, {
             encoding: 'utf-8',
         });
 
         for (const fileOrDir of dirFiles) {
             const fileOrDirPath = path.join(dir, fileOrDir);
-            const stats = await util.promisify(stat)(fileOrDirPath);
+            const stats = await fsPromises.stat(fileOrDirPath);
             if (stats.isDirectory()) {
                 maps.push(...(await this.getMapFilesFromDirAsync(fileOrDirPath)));
             } else if (this.isMapFile(fileOrDir)) {

--- a/tools/mpmaps-updater/service/mpmaps-updater.service.ts
+++ b/tools/mpmaps-updater/service/mpmaps-updater.service.ts
@@ -1,15 +1,21 @@
-import { access, constants as fsConstants, readFile, writeFileSync } from 'fs';
-import { createConstants, MpMapsUpdaterConstants } from 'mpmaps-updater/constants';
-import { IniFile } from 'mpmaps-updater/class/ini-file.class';
-import { MpMapsFileService } from 'mpmaps-updater/class/mp-maps-file.service';
-import { SortedMapSection } from 'mpmaps-updater/interface/sorted-map-section.interface';
-import { MapLoaderService } from 'mpmaps-updater/service/map-loader.service';
 import { parseArgs } from 'util';
-import * as util from 'util';
-import { IIniObject, parse as parseIni, stringify } from 'js-ini';
+import * as fsPromises from 'fs/promises';
+
+import { parse as parseIni, stringify } from 'js-ini';
+import type { IIniObject, IIniObjectSection } from 'js-ini';
+
+import { createConstants } from 'mpmaps-updater/constants';
+import { IniFile } from 'mpmaps-updater/class/ini-file.class';
+import { MapLoaderService } from 'mpmaps-updater/service/map-loader.service';
+import { MpMapsFileService } from 'mpmaps-updater/class/mp-maps-file.service';
+import { type ISortedMapSection } from 'mpmaps-updater/interface/sorted-map-section.interface';
+
+function isIniSection(value: unknown): value is IIniObjectSection {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
 
 export class MpMapsUpdaterService {
-    private constants: MpMapsUpdaterConstants;
+    private constants: ReturnType<typeof createConstants>;
 
     private mpMapsIniFileService: MpMapsFileService;
     private mapLoaderService: MapLoaderService;
@@ -83,22 +89,30 @@ export class MpMapsUpdaterService {
         // This is the property of each map that we sort on when ordering them in the [MultiMaps] section.
         // This will also dictate how they are default sorted in the client game lobby.
         const sortKey: string = 'Description';
-        const sortedMapSections: SortedMapSection[] = allMapKeys
-            .map((mapKey) => {
+        const sortedMapSections: ISortedMapSection[] = allMapKeys
+            .map((mapKey): ISortedMapSection | null => {
+                const section = mpMapsIniFile.getSection(mapKey);
+                if (!isIniSection(section)) {
+                    return null;
+                }
+
                 // create simple array of objects for each map key and the map section in the MPMaps.ini file
                 return {
                     mapKey,
-                    section: mpMapsIniFile.getSection(mapKey),
+                    section,
                 };
             })
+            .filter((mapSection): mapSection is ISortedMapSection => mapSection !== null)
             .filter((m, index, allMaps) => {
                 // create unique array
                 return allMaps.findIndex((_m) => _m.mapKey === m.mapKey) === index;
             })
-            .sort((mapObjA: any, mapObjB: any) => {
+            .sort((mapObjA, mapObjB) => {
                 // sort the simple array by "sortKey" above
-                if (mapObjA.section[sortKey] === mapObjB.section[sortKey]) return 0;
-                return mapObjA.section[sortKey] > mapObjB.section[sortKey] ? 1 : -1;
+                const valueA = mapObjA.section[sortKey];
+                const valueB = mapObjB.section[sortKey];
+                if (valueA === valueB) return 0;
+                return String(valueA) > String(valueB) ? 1 : -1;
             });
 
         // Use the map path as the key to produce stable, minimal diffs.
@@ -112,24 +126,32 @@ export class MpMapsUpdaterService {
         mpMapsIniFile.setMultiMapsSection(multiMapsSection);
     }
 
-    private async getNewMapSection(mapIniFile: IniFile): Promise<any> {
-        const newSection = Object.assign(
+    private async getNewMapSection(mapIniFile: IniFile): Promise<IIniObjectSection> {
+        const newSection: IIniObjectSection = Object.assign(
             {},
-            mapIniFile.getMapSection() || {},
-            mapIniFile.getBasicSection() || {},
-            mapIniFile,
+            this.getOptionalIniSection(mapIniFile.getMapSection()),
+            this.getOptionalIniSection(mapIniFile.getBasicSection()),
         );
-        const headerSection = mapIniFile.getHeaderSection() || {};
-        const maxWaypoints = parseInt(headerSection['NumberStartingPoints']) || this.constants.maxWaypoints;
+        const headerSection = this.getOptionalIniSection(mapIniFile.getHeaderSection());
+        const rawMaxWaypoints = headerSection['NumberStartingPoints'];
+        const parsedMaxWaypoints =
+            typeof rawMaxWaypoints === 'string' ? Number.parseInt(rawMaxWaypoints, 10) : Number.NaN;
+        const maxWaypoints =
+            Number.isFinite(parsedMaxWaypoints) && parsedMaxWaypoints > 0
+                ? parsedMaxWaypoints
+                : this.constants.maxWaypoints;
         const waypoints = mapIniFile.getWaypointsSectionValues();
         for (let i = 0; i < maxWaypoints; i++) {
-            newSection[`Waypoint${i}`] = waypoints[i];
+            const waypoint = waypoints[i];
+            if (waypoint !== undefined) {
+                newSection[`Waypoint${i}`] = waypoint;
+            }
         }
 
         return await this.normalizeSection(mapIniFile, newSection);
     }
 
-    private async normalizeSection(mapIniFile: IniFile, newSection: any): Promise<any> {
+    private async normalizeSection(mapIniFile: IniFile, newSection: IIniObjectSection): Promise<IIniObjectSection> {
         console.log('Normalizing new map section');
         const gameMode = this.getRequiredSectionValue(mapIniFile, newSection, 'GameMode');
         const maxPlayer = this.getRequiredSectionValue(mapIniFile, newSection, 'MaxPlayer');
@@ -144,9 +166,10 @@ export class MpMapsUpdaterService {
         delete newSection['Name'];
 
         // only pull properties that we've whitelisted
-        for (let key of Object.keys(newSection)) {
-            if (!this.constants.newMapSectionWhitelist.find((item) => new RegExp(`^${item}$`).test(key)))
+        for (const key of Object.keys(newSection)) {
+            if (!this.constants.newMapSectionWhitelist.find((item) => new RegExp(`^${item}$`).test(key))) {
                 delete newSection[key];
+            }
         }
 
         await this.normalizeGameModes(newSection);
@@ -156,13 +179,13 @@ export class MpMapsUpdaterService {
             .sort((a, b) => {
                 return a > b ? 1 : -1;
             })
-            .reduce((obj, key) => {
+            .reduce<IIniObjectSection>((obj, key) => {
                 obj[key] = newSection[key];
                 return obj;
             }, {});
     }
 
-    private getRequiredSectionValue(mapIniFile: IniFile, section: any, key: string): string {
+    private getRequiredSectionValue(mapIniFile: IniFile, section: IIniObjectSection, key: string): string {
         const value = section[key];
         if (typeof value === 'string' && value.trim()) {
             return value;
@@ -173,12 +196,17 @@ export class MpMapsUpdaterService {
         );
     }
 
-    private async normalizeGameModes(section: any): Promise<void> {
-        const gameModes = section['GameModes'].split(',') || [];
+    private async normalizeGameModes(section: IIniObjectSection): Promise<void> {
+        const gameModesValue = section['GameModes'];
+        const gameModes = typeof gameModesValue === 'string' ? gameModesValue.split(',') : [];
         for (let i = 0; i < gameModes.length; i++) {
             gameModes[i] = await this.normalizeGameMode(gameModes[i]);
         }
         section['GameModes'] = gameModes.join(',');
+    }
+
+    private getOptionalIniSection(value: unknown): IIniObjectSection {
+        return isIniSection(value) ? value : {};
     }
 
     private async normalizeGameMode(gameMode: string): Promise<string> {
@@ -220,9 +248,9 @@ export class MpMapsUpdaterService {
 
     /**
      * If .map files are removed from the repo, we must also remove them from the MPMaps.ini file.
-     * @param {IniFile} mpMapsIniFile the file to remove maps from
-     * @param {IniFile[]} mapIniFiles the list of maps found on the system
-     * @return {string[]} missing map keys
+     * @param mpMapsIniFile the file to remove maps from
+     * @param mapIniFiles the list of maps found on the system
+     * @returns the missing map keys
      */
     private async removeMissingMaps(mpMapsIniFile: IniFile, mapIniFiles: IniFile[]): Promise<string[]> {
         console.log('Checking for removed maps');
@@ -263,7 +291,7 @@ export class MpMapsUpdaterService {
 
     /**
      * This adds entries to the updateexec file in the [Delete] section for all removed maps
-     * @param {string[]} missingMapKeys
+     * @param missingMapKeys the map keys that should be added to the delete list
      */
     private async addRemovedMapsToUpdateExec(missingMapKeys: string[]): Promise<void> {
         const updateExecIniFile = await this.getUpdateExecIniFile();
@@ -280,10 +308,10 @@ export class MpMapsUpdaterService {
     }
 
     /**
-     * Get the content of the existing updateexec file as an IIniObject
+     * Get the content of the existing updateexec file.
      */
     private async getUpdateExecIniFile(): Promise<IIniObject> {
-        const updateExecContent = await util.promisify(readFile)(this.constants.paths.updateExec, {
+        const updateExecContent = await fsPromises.readFile(this.constants.paths.updateExec, {
             encoding: 'utf-8',
         });
         return parseIni(updateExecContent, {
@@ -297,11 +325,11 @@ export class MpMapsUpdaterService {
 
     /**
      * Write out data to the updateexec file
-     * @param {IIniObject} data
+     * @param data the INI object content to write
      */
     private async writeUpdateExecIniFile(data: IIniObject): Promise<void> {
         const updateExecContent = stringify(data, {}).trim();
-        writeFileSync(this.constants.paths.updateExec, updateExecContent, 'utf8');
+        await fsPromises.writeFile(this.constants.paths.updateExec, updateExecContent, 'utf8');
     }
 
     /**
@@ -322,11 +350,11 @@ export class MpMapsUpdaterService {
      * @private
      */
     private async checkForRequiredFileAsync(fileOrDirPath: string): Promise<void> {
-        access(fileOrDirPath, fsConstants.F_OK, (err) => {
-            if (err) {
-                console.error(`Unable to access file ${fileOrDirPath}`);
-                throw err;
-            }
-        });
+        try {
+            await fsPromises.access(fileOrDirPath);
+        } catch (error) {
+            console.error(`Unable to access file ${fileOrDirPath}`);
+            throw error;
+        }
     }
 }

--- a/tools/package-lock.json
+++ b/tools/package-lock.json
@@ -17,11 +17,11 @@
         "release-tag-validator",
         "version-writer"
       ],
-      "dependencies": {
-        "tsx": "^4.21.0"
-      },
       "devDependencies": {
         "prettier": "^3.8.1"
+      },
+      "engines": {
+        "node": ">= 24"
       }
     },
     "build-installer": {
@@ -33,6 +33,7 @@
       },
       "devDependencies": {
         "@types/node": "^24.12.2",
+        "@types/twig": "^1.12.17",
         "typescript": "^6.0.2"
       }
     },
@@ -40,7 +41,7 @@
       "name": "cncnet-core",
       "version": "1.0.0",
       "dependencies": {
-        "@actions/github": "^6.0.1",
+        "@actions/github": "^9.1.0",
         "commander": "^12.1.0",
         "irc": "^0.5.2",
         "ssh2": "^1.17.0",
@@ -91,28 +92,28 @@
       }
     },
     "node_modules/@actions/github": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.1.tgz",
-      "integrity": "sha512-xbZVcaqD4XnQAe35qSQqskb3SqIAfRyLBrHMd/8TuL7hJSz2QtbDwnNM8zWx4zO5l2fnGtseNE3MbEvD7BxVMw==",
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/@actions/github/-/github-9.1.0.tgz",
+      "integrity": "sha512-u0hDGQeCS+7VNoLA8hYG65RLdPLMaPGfka0sZ0up7P0AiShqfX6xcuXNteGkQ7X7Tod7AMNwHd4p7DS63i8zzA==",
       "license": "MIT",
       "dependencies": {
-        "@actions/http-client": "^2.2.0",
-        "@octokit/core": "^5.0.1",
-        "@octokit/plugin-paginate-rest": "^9.2.2",
-        "@octokit/plugin-rest-endpoint-methods": "^10.4.0",
-        "@octokit/request": "^8.4.1",
-        "@octokit/request-error": "^5.1.1",
-        "undici": "^5.28.5"
+        "@actions/http-client": "^3.0.2",
+        "@octokit/core": "^7.0.6",
+        "@octokit/plugin-paginate-rest": "^14.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "^17.0.0",
+        "@octokit/request": "^10.0.7",
+        "@octokit/request-error": "^7.1.0",
+        "undici": "^6.23.0"
       }
     },
     "node_modules/@actions/http-client": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
-      "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-3.0.2.tgz",
+      "integrity": "sha512-JP38FYYpyqvUsz+Igqlc/JG6YO9PaKuvqjM3iGvaLqFnJ7TFmcLyy2IDrY0bI0qCQug8E9K+elv5ZNfw62ZJzA==",
       "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",
-        "undici": "^5.25.4"
+        "undici": "^6.23.0"
       }
     },
     "node_modules/@babel/runtime": {
@@ -540,171 +541,132 @@
         "node": ">=18"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
-      }
-    },
     "node_modules/@octokit/auth-token": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
-      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
+      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
       "license": "MIT",
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@octokit/core": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
-      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
+      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/auth-token": "^4.0.0",
-        "@octokit/graphql": "^7.1.0",
-        "@octokit/request": "^8.4.1",
-        "@octokit/request-error": "^5.1.1",
-        "@octokit/types": "^13.0.0",
-        "before-after-hook": "^2.2.0",
-        "universal-user-agent": "^6.0.0"
+        "@octokit/auth-token": "^6.0.0",
+        "@octokit/graphql": "^9.0.3",
+        "@octokit/request": "^10.0.6",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "before-after-hook": "^4.0.0",
+        "universal-user-agent": "^7.0.0"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
-      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
+      "version": "11.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
+      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^13.1.0",
-        "universal-user-agent": "^6.0.0"
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.2"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
-      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
+      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/request": "^8.4.1",
-        "@octokit/types": "^13.0.0",
-        "universal-user-agent": "^6.0.0"
+        "@octokit/request": "^10.0.6",
+        "@octokit/types": "^16.0.0",
+        "universal-user-agent": "^7.0.0"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "24.2.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
-      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
+      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "9.2.2",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
-      "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
+      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^12.6.0"
+        "@octokit/types": "^16.0.0"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       },
       "peerDependencies": {
-        "@octokit/core": "5"
-      }
-    },
-    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/openapi-types": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
-      "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-paginate-rest/node_modules/@octokit/types": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^20.0.0"
+        "@octokit/core": ">=6"
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
-      "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
+      "version": "17.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
+      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^12.6.0"
+        "@octokit/types": "^16.0.0"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       },
       "peerDependencies": {
-        "@octokit/core": "5"
-      }
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/openapi-types": {
-      "version": "20.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
-      "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
-      "license": "MIT"
-    },
-    "node_modules/@octokit/plugin-rest-endpoint-methods/node_modules/@octokit/types": {
-      "version": "12.6.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
-      "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-      "license": "MIT",
-      "dependencies": {
-        "@octokit/openapi-types": "^20.0.0"
+        "@octokit/core": ">=6"
       }
     },
     "node_modules/@octokit/request": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
-      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
+      "version": "10.0.8",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.8.tgz",
+      "integrity": "sha512-SJZNwY9pur9Agf7l87ywFi14W+Hd9Jg6Ifivsd33+/bGUQIjNujdFiXII2/qSlN2ybqUHfp5xpekMEjIBTjlSw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/endpoint": "^9.0.6",
-        "@octokit/request-error": "^5.1.1",
-        "@octokit/types": "^13.1.0",
-        "universal-user-agent": "^6.0.0"
+        "@octokit/endpoint": "^11.0.3",
+        "@octokit/request-error": "^7.0.2",
+        "@octokit/types": "^16.0.0",
+        "fast-content-type-parse": "^3.0.0",
+        "json-with-bigint": "^3.5.3",
+        "universal-user-agent": "^7.0.2"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
-      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
+      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^13.1.0",
-        "deprecation": "^2.0.0",
-        "once": "^1.4.0"
+        "@octokit/types": "^16.0.0"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@octokit/types": {
-      "version": "13.10.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
-      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
+      "version": "16.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
+      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/openapi-types": "^24.2.0"
+        "@octokit/openapi-types": "^27.0.0"
       }
     },
     "node_modules/@types/fs-extra": {
@@ -772,6 +734,13 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/twig": {
+      "version": "1.12.17",
+      "resolved": "https://registry.npmjs.org/@types/twig/-/twig-1.12.17.tgz",
+      "integrity": "sha512-Lxcjgzt4mlDrv1xp1EdoBLPTxpjLAt9vtN3/qoblC5D6hMCYgZJOQHfaT/0gwCcAZENnKQ7Sga28DSsckPWa0g==",
       "dev": true,
       "license": "MIT"
     },
@@ -847,9 +816,9 @@
       }
     },
     "node_modules/before-after-hook": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
-      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
+      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
       "license": "Apache-2.0"
     },
     "node_modules/bl": {
@@ -1152,12 +1121,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/deprecation": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
-      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-      "license": "ISC"
-    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -1251,6 +1214,22 @@
         "@esbuild/win32-ia32": "0.27.7",
         "@esbuild/win32-x64": "0.27.7"
       }
+    },
+    "node_modules/fast-content-type-parse": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
+      "integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/fast-folder-size": {
       "version": "2.4.0",
@@ -1626,6 +1605,12 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/js-ini/-/js-ini-1.6.0.tgz",
       "integrity": "sha512-9Vx+NVkMRNY4i7pLLIGdXIQbP1iwB3fP2IG1zMCgeUUvR1ODmTKa33eR/J9FHoorNsfoJr9/2SVqeSKLwPD9Nw==",
+      "license": "MIT"
+    },
+    "node_modules/json-with-bigint": {
+      "version": "3.5.8",
+      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
+      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
       "license": "MIT"
     },
     "node_modules/jsonfile": {
@@ -2132,15 +2117,12 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {
@@ -2151,9 +2133,9 @@
       "license": "MIT"
     },
     "node_modules/universal-user-agent": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
-      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
+      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
       "license": "ISC"
     },
     "node_modules/universalify": {
@@ -2233,7 +2215,7 @@
     "publish-release": {
       "version": "1.0.0",
       "dependencies": {
-        "@actions/github": "^6.0.1",
+        "@actions/github": "^9.1.0",
         "cncnet-core": "1.0.0",
         "tsx": "^4.21.0"
       },
@@ -2245,7 +2227,7 @@
     "release-asset-uploader": {
       "version": "1.0.0",
       "dependencies": {
-        "@actions/github": "^6.0.1",
+        "@actions/github": "^9.1.0",
         "cncnet-core": "1.0.0",
         "tsx": "^4.21.0"
       },
@@ -2257,7 +2239,7 @@
     "release-tag-validator": {
       "version": "1.0.0",
       "dependencies": {
-        "@actions/github": "^6.0.1",
+        "@actions/github": "^9.1.0",
         "cncnet-core": "1.0.0",
         "tsx": "^4.21.0"
       },

--- a/tools/package.json
+++ b/tools/package.json
@@ -1,6 +1,7 @@
 {
   "name": "cncnet-yr-client-package-tools",
   "private": true,
+  "type": "module",
   "description": "",
   "author": "",
   "license": "ISC",

--- a/tools/publish-release/index.ts
+++ b/tools/publish-release/index.ts
@@ -1,4 +1,7 @@
 import { PublishReleaseService } from './services/publish-release.service';
 
 PublishReleaseService.run() //
-    .catch(console.error);
+    .catch((error) => {
+        console.error(error);
+        process.exitCode = 1;
+    });

--- a/tools/publish-release/package.json
+++ b/tools/publish-release/package.json
@@ -2,6 +2,7 @@
   "name": "publish-release",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "main": "./index.ts",
   "scripts": {
     "start": "tsx index.ts",
@@ -9,7 +10,7 @@
   },
   "dependencies": {
     "tsx": "^4.21.0",
-    "@actions/github": "^6.0.1",
+    "@actions/github": "^9.1.0",
     "cncnet-core": "1.0.0"
   },
   "devDependencies": {

--- a/tools/publish-release/services/publish-release.service.ts
+++ b/tools/publish-release/services/publish-release.service.ts
@@ -1,11 +1,14 @@
-import { IrcServerConfig } from 'cncnet-core/class/irc-server-config.class';
+import { context as githubContext } from '@actions/github';
+
+import { type IIrcServerConfig } from 'cncnet-core/interface/irc-server-config.interface';
 import { PublishReleaseOptionValues } from 'cncnet-core/class/publish-release-option-values.class';
 import { AbstractRepoService } from 'cncnet-core/service/abstract-repo.service';
 import { IrcClientService } from 'cncnet-core/service/irc-client.service';
 import { SshClientService } from 'cncnet-core/service/ssh-client.service';
-import { Context } from '@actions/github/lib/context';
 
 const tagRegex = /^yr-(?<major>\d+).(?<minor>\d+)(?:\.(?<patch>\d+))*$/;
+
+type PublishReleaseContext = Pick<typeof githubContext, 'repo'>;
 
 type PublishReleaseGitHub = {
     rest: {
@@ -55,7 +58,7 @@ export class PublishReleaseService extends AbstractRepoService<PublishReleaseOpt
         this.createIrcClient =
             dependencies.createIrcClient ||
             ((options, releaseVersion) => {
-                const config: IrcServerConfig = {
+                const config: IIrcServerConfig = {
                     server: options.ircServer,
                     userName: options.ircUserName,
                     nick: options.ircNick,
@@ -68,11 +71,14 @@ export class PublishReleaseService extends AbstractRepoService<PublishReleaseOpt
             });
     }
 
-    public static run(context?: any | Context, dependencies?: PublishReleaseDependencies): Promise<void> {
-        return new PublishReleaseService(dependencies).run(context || new Context());
+    public static async run(
+        context: PublishReleaseContext = githubContext,
+        dependencies?: PublishReleaseDependencies,
+    ): Promise<void> {
+        return new PublishReleaseService(dependencies).run(context);
     }
 
-    private async run(context: any | Context): Promise<void> {
+    private async run(context: PublishReleaseContext): Promise<void> {
         const releaseVersion = await this.getLatestReleaseNumber(context);
 
         await this.publishReleaseVersionOnServer(releaseVersion);
@@ -80,13 +86,13 @@ export class PublishReleaseService extends AbstractRepoService<PublishReleaseOpt
     }
 
     /**
-     * Gets the latest release number for the latest release. It does this by getting the latest release from Github,
-     * then parsing the "tag" for that lease in our expected format of "yr-x.y" or "yr-x.y.z".
+     * Gets the latest release number for the latest release. It does this by getting the latest release from GitHub,
+     * then parsing the tag for that release in our expected format of "yr-x.y" or "yr-x.y.z",
      * where "x.y" or "x.y.z" is the release number.
-     * @param context
+     * @param context the repository information used to query the latest release
      * @private
      */
-    private async getLatestReleaseNumber(context: any | Context): Promise<string> {
+    private async getLatestReleaseNumber(context: PublishReleaseContext): Promise<string> {
         const github = this.getRequiredGitHub();
         const response = await github.rest.repos.getLatestRelease({
             owner: context.repo.owner,
@@ -107,7 +113,7 @@ export class PublishReleaseService extends AbstractRepoService<PublishReleaseOpt
     /**
      * Publishes the specified release number.
      * This creates or modifies the "live" link to point to the directory for the specified release version.
-     * @param releaseVersion
+     * @param releaseVersion the release version to publish on the server
      * @private
      */
     private async publishReleaseVersionOnServer(releaseVersion: string): Promise<void> {
@@ -129,7 +135,7 @@ export class PublishReleaseService extends AbstractRepoService<PublishReleaseOpt
     /**
      * Parses the tag name into a release version in the form "x.y" or "x.y.z"
      *
-     * @param tagName Tag name to be parsed. It should be in the form "yr-x.y.z"
+     * @param tagName the tag name to parse, expected in the form "yr-x.y.z"
      * @private
      */
     private async getReleaseVersionForTag(tagName: string): Promise<string> {

--- a/tools/publish-release/test.ts
+++ b/tools/publish-release/test.ts
@@ -1,6 +1,7 @@
+import { PublishReleaseOptionValues } from 'cncnet-core/class/publish-release-option-values.class';
+
 import { PublishReleaseService } from './services/publish-release.service';
 import { testPublishRelease } from './test-data/test-publish-release';
-import { PublishReleaseOptionValues } from 'cncnet-core/class/publish-release-option-values.class';
 
 const mockGitHub = {
     rest: {
@@ -46,4 +47,7 @@ PublishReleaseService.run(testPublishRelease, {
             console.log(`Mock IRC postUpdateMessage for release ${releaseVersion}`);
         },
     }),
-}).catch(console.error);
+}).catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+});

--- a/tools/release-asset-uploader/index.ts
+++ b/tools/release-asset-uploader/index.ts
@@ -1,4 +1,7 @@
 ﻿import { ReleaseAssetUploaderService } from './service/release-asset-uploader.service';
 
 ReleaseAssetUploaderService.run() //
-    .catch(console.error);
+    .catch((error) => {
+        console.error(error);
+        process.exitCode = 1;
+    });

--- a/tools/release-asset-uploader/package.json
+++ b/tools/release-asset-uploader/package.json
@@ -2,6 +2,7 @@
   "name": "release-asset-uploader",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "main": "./index.ts",
   "scripts": {
     "start": "tsx index.ts",
@@ -9,7 +10,7 @@
   },
   "dependencies": {
     "tsx": "^4.21.0",
-    "@actions/github": "^6.0.1",
+    "@actions/github": "^9.1.0",
     "cncnet-core": "1.0.0"
   },
   "devDependencies": {

--- a/tools/release-asset-uploader/service/release-asset-uploader.service.ts
+++ b/tools/release-asset-uploader/service/release-asset-uploader.service.ts
@@ -1,8 +1,12 @@
-﻿import { Context } from '@actions/github/lib/context';
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { context as githubContext } from '@actions/github';
+
 import { ReleaseAssetUploaderOptionValues } from 'cncnet-core/class/release-asset-uploader-option-values.class';
 import { AbstractRepoService } from 'cncnet-core/service/abstract-repo.service';
-import { existsSync, readFileSync } from 'fs';
-import { resolve } from 'path';
+
+type ReleaseAssetUploaderContext = Pick<typeof githubContext, 'ref' | 'repo'>;
 
 type ReleaseAssetUploaderGitHub = {
     rest: {
@@ -36,15 +40,18 @@ export class ReleaseAssetUploaderService extends AbstractRepoService<ReleaseAsse
         }
     }
 
-    public static run(context?: Context | any, dependencies?: ReleaseAssetUploaderDependencies): Promise<void> {
-        return new ReleaseAssetUploaderService(dependencies).run(context || new Context());
+    public static async run(
+        context: ReleaseAssetUploaderContext = githubContext,
+        dependencies?: ReleaseAssetUploaderDependencies,
+    ): Promise<void> {
+        return new ReleaseAssetUploaderService(dependencies).run(context);
     }
 
     protected getOptionValues(): ReleaseAssetUploaderOptionValues {
         return ReleaseAssetUploaderOptionValues.parse();
     }
 
-    private async run(context: any | Context): Promise<void> {
+    private async run(context: ReleaseAssetUploaderContext): Promise<void> {
         const tagName = super.getTagName(context.ref);
         if (!tagName) {
             console.log('No tag/release to upload asset to');
@@ -69,12 +76,12 @@ export class ReleaseAssetUploaderService extends AbstractRepoService<ReleaseAsse
             return;
         }
 
-        const fullAssetPath = resolve(process.cwd(), assetPath);
+        const fullAssetPath = path.resolve(process.cwd(), assetPath);
         console.log(`Checking to see if asset exists at ${fullAssetPath}`);
-        if (!existsSync(fullAssetPath)) throw `Asset does not exist at: ${fullAssetPath}`;
+        if (!fs.existsSync(fullAssetPath)) throw `Asset does not exist at: ${fullAssetPath}`;
 
         console.log(`Reading asset file data`);
-        const data: unknown = readFileSync(fullAssetPath);
+        const data: unknown = fs.readFileSync(fullAssetPath);
 
         console.log(`Uploading asset to release`);
         const uploadResponse = await github.rest.repos.uploadReleaseAsset({

--- a/tools/release-asset-uploader/test.ts
+++ b/tools/release-asset-uploader/test.ts
@@ -2,10 +2,12 @@
  * This is a simple script to test the action.
  */
 
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
 import { ReleaseAssetUploaderOptionValues } from 'cncnet-core/class/release-asset-uploader-option-values.class';
-import { mkdtempSync, rmSync, writeFileSync } from 'fs';
-import { tmpdir } from 'os';
-import { join } from 'path';
+
 import { ReleaseAssetUploaderService } from './service/release-asset-uploader.service';
 import { testPackageContext } from './test-data/test-package';
 
@@ -48,10 +50,10 @@ const mockGitHub = {
 };
 
 async function run(): Promise<void> {
-    const tempDir = mkdtempSync(join(tmpdir(), 'release-asset-uploader-test-'));
-    const assetPath = join(tempDir, 'test-asset.txt');
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'release-asset-uploader-test-'));
+    const assetPath = path.join(tempDir, 'test-asset.txt');
 
-    writeFileSync(assetPath, 'test release asset uploader payload');
+    fs.writeFileSync(assetPath, 'test release asset uploader payload');
 
     const testOptionValues = {
         assetName: 'test-asset.txt',
@@ -64,11 +66,15 @@ async function run(): Promise<void> {
             optionValues: testOptionValues,
         });
     } finally {
-        rmSync(tempDir, {
+        fs.rmSync(tempDir, {
             recursive: true,
             force: true,
         });
     }
 }
 
-run().catch(console.error);
+run() //
+    .catch((error) => {
+        console.error(error);
+        process.exitCode = 1;
+    });

--- a/tools/release-tag-validator/index.ts
+++ b/tools/release-tag-validator/index.ts
@@ -1,3 +1,7 @@
 ﻿import { ReleaseTagValidatorService } from './service/release-tag-validator.service';
 
-ReleaseTagValidatorService.run();
+ReleaseTagValidatorService.run() //
+    .catch((error) => {
+        console.error(error);
+        process.exitCode = 1;
+    });

--- a/tools/release-tag-validator/package.json
+++ b/tools/release-tag-validator/package.json
@@ -2,6 +2,7 @@
   "name": "release-tag-validator",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "main": "./index.ts",
   "scripts": {
     "start": "tsx index.ts",
@@ -9,7 +10,7 @@
   },
   "dependencies": {
     "tsx": "^4.21.0",
-    "@actions/github": "^6.0.1",
+    "@actions/github": "^9.1.0",
     "cncnet-core": "1.0.0"
   },
   "devDependencies": {

--- a/tools/release-tag-validator/service/release-tag-validator.service.ts
+++ b/tools/release-tag-validator/service/release-tag-validator.service.ts
@@ -1,13 +1,16 @@
-﻿import { Context } from '@actions/github/lib/context';
+import { context as githubContext } from '@actions/github';
+
 import { DefaultOptionValues } from 'cncnet-core/class/default-option-values.class';
 import { AbstractRepoService } from 'cncnet-core/service/abstract-repo.service';
+
+type ReleaseTagValidatorContext = Pick<typeof githubContext, 'eventName' | 'ref'>;
 
 /**
  * This action is meant to be run with the github-script action:
  * https://github.com/actions/github-script
  */
 export class ReleaseTagValidatorService extends AbstractRepoService<DefaultOptionValues> {
-    private run(context: Context): void {
+    private run(context: ReleaseTagValidatorContext): void {
         console.log(`Running ReleaseTagValidatorAction`);
         if (!super.isRelease(context.eventName)) {
             console.log('Not a release');
@@ -27,8 +30,8 @@ export class ReleaseTagValidatorService extends AbstractRepoService<DefaultOptio
         throw `Invalid tag specified: ${context.ref}. Must be in the format 'yr-0.0' or 'yr-0.0.0'.`;
     }
 
-    public static run(context?: Context | any): void {
-        new ReleaseTagValidatorService().run(context || new Context());
+    public static async run(context: ReleaseTagValidatorContext = githubContext): Promise<void> {
+        new ReleaseTagValidatorService().run(context);
     }
 
     protected getOptionValues(): DefaultOptionValues {

--- a/tools/release-tag-validator/test.ts
+++ b/tools/release-tag-validator/test.ts
@@ -7,11 +7,19 @@ import { testBadReleaseTagContext } from './test-data/test-bad-release-tag-conte
 import { testGoodReleaseTagContext } from './test-data/test-good-release-tag-context';
 import { testNonReleaseContext } from './test-data/test-non-release-context';
 
-ReleaseTagValidatorService.run(testGoodReleaseTagContext);
-ReleaseTagValidatorService.run(testNonReleaseContext);
+async function run(): Promise<void> {
+    await ReleaseTagValidatorService.run(testGoodReleaseTagContext);
+    await ReleaseTagValidatorService.run(testNonReleaseContext);
 
-try {
-    ReleaseTagValidatorService.run(testBadReleaseTagContext);
-} catch (e) {
-    console.error(e);
+    try {
+        await ReleaseTagValidatorService.run(testBadReleaseTagContext);
+    } catch (e) {
+        console.error(e);
+    }
 }
+
+run() //
+    .catch((error) => {
+        console.error(error);
+        process.exitCode = 1;
+    });

--- a/tools/tsconfig.json
+++ b/tools/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "noEmit": true,
+    "verbatimModuleSyntax": true,
     "paths": {
       "build-installer/*": ["./build-installer/*"],
       "cncnet-core/*": ["./core/*"],

--- a/tools/version-writer/constants.ts
+++ b/tools/version-writer/constants.ts
@@ -1,11 +1,13 @@
-import { resolve } from 'path';
+import * as path from 'path';
+import * as url from 'url';
 
 export function createConstants(workingDir: string) {
-    const resolvedWorkingDir = resolve(workingDir);
-    const versionWriterBinary = resolve(__dirname, 'bin/VersionWriter.exe');
-    const runnerBinary = resolve(resolvedWorkingDir, 'VersionWriter.runtime.exe');
-    const versionConfigPath = resolve(resolvedWorkingDir, 'versionconfig.ini');
-    const winePrefixPath = resolve(__dirname, '.wine');
+    const currentDir = path.dirname(url.fileURLToPath(import.meta.url));
+    const resolvedWorkingDir = path.resolve(workingDir);
+    const versionWriterBinary = path.resolve(currentDir, 'bin/VersionWriter.exe');
+    const runnerBinary = path.resolve(resolvedWorkingDir, 'VersionWriter.runtime.exe');
+    const versionConfigPath = path.resolve(resolvedWorkingDir, 'versionconfig.ini');
+    const winePrefixPath = path.resolve(currentDir, '.wine');
 
     return {
         commands: {
@@ -21,5 +23,3 @@ export function createConstants(workingDir: string) {
         },
     };
 }
-
-export type VersionWriterConstants = ReturnType<typeof createConstants>;

--- a/tools/version-writer/package.json
+++ b/tools/version-writer/package.json
@@ -2,6 +2,7 @@
   "name": "version-writer",
   "version": "1.0.0",
   "private": true,
+  "type": "module",
   "main": "./index.ts",
   "scripts": {
     "start": "tsx index.ts"

--- a/tools/version-writer/service/version-writer.service.ts
+++ b/tools/version-writer/service/version-writer.service.ts
@@ -1,17 +1,18 @@
-import { spawn } from 'child_process';
-import { createConstants, VersionWriterConstants } from 'version-writer/constants';
-import { access, copyFile, mkdir, rm } from 'fs/promises';
-import { resolve } from 'path';
 import { parseArgs } from 'util';
+import * as childProcess from 'child_process';
+import * as fsPromises from 'fs/promises';
+import * as path from 'path';
 
-interface CommandOptions {
+import { createConstants } from 'version-writer/constants';
+
+interface ICommandOptions {
     command: string;
     args: string[];
     env?: NodeJS.ProcessEnv;
 }
 
 export class VersionWriterService {
-    private constants: VersionWriterConstants;
+    private constants: ReturnType<typeof createConstants>;
 
     public constructor(private workingDir: string) {
         this.constants = createConstants(workingDir);
@@ -50,15 +51,15 @@ export class VersionWriterService {
     }
 
     private async validateWorkingDir(): Promise<void> {
-        await access(this.constants.paths.workingDir);
-        await access(this.constants.paths.versionConfigPath);
+        await fsPromises.access(this.constants.paths.workingDir);
+        await fsPromises.access(this.constants.paths.versionConfigPath);
     }
 
     private async prepareRunnerBinary(): Promise<void> {
-        await copyFile(this.constants.paths.versionWriterBinary, this.constants.paths.runnerBinary);
+        await fsPromises.copyFile(this.constants.paths.versionWriterBinary, this.constants.paths.runnerBinary);
     }
 
-    private async getCommandOptions(): Promise<CommandOptions> {
+    private async getCommandOptions(): Promise<ICommandOptions> {
         if (process.platform === 'win32') {
             return {
                 command: this.constants.paths.runnerBinary,
@@ -73,7 +74,7 @@ export class VersionWriterService {
         throw new Error(`Unsupported platform for version-writer: ${process.platform}`);
     }
 
-    private async getLinuxCommandOptions(): Promise<CommandOptions> {
+    private async getLinuxCommandOptions(): Promise<ICommandOptions> {
         if (await this.isCommandAvailable(this.constants.commands.mono, ['--version'])) {
             console.log('Running VersionWriter.exe via mono');
             return {
@@ -83,7 +84,7 @@ export class VersionWriterService {
         }
 
         if (await this.isCommandAvailable(this.constants.commands.wine, ['--version'])) {
-            await mkdir(this.constants.paths.winePrefixPath, { recursive: true });
+            await fsPromises.mkdir(this.constants.paths.winePrefixPath, { recursive: true });
             console.log(
                 `Running VersionWriter.exe via wine with local prefix '${this.constants.paths.winePrefixPath}'`,
             );
@@ -108,7 +109,7 @@ export class VersionWriterService {
 
     private async isCommandAvailable(command: string, args: string[]): Promise<boolean> {
         return await new Promise((resolvePromise) => {
-            const child = spawn(command, args, {
+            const child = childProcess.spawn(command, args, {
                 stdio: 'ignore',
             });
 
@@ -127,9 +128,9 @@ export class VersionWriterService {
         });
     }
 
-    private async runCommand(options: CommandOptions): Promise<void> {
+    private async runCommand(options: ICommandOptions): Promise<void> {
         await new Promise<void>((resolvePromise, reject) => {
-            const versionWriter = spawn(options.command, options.args, {
+            const versionWriter = childProcess.spawn(options.command, options.args, {
                 cwd: this.constants.paths.workingDir,
                 env: options.env,
             });
@@ -162,13 +163,13 @@ export class VersionWriterService {
     }
 
     private async deleteRunnerBinary(): Promise<void> {
-        return rm(this.constants.paths.runnerBinary, {
+        return fsPromises.rm(this.constants.paths.runnerBinary, {
             force: true,
         });
     }
 
     private async deleteVersionWriterCopiedFiles(): Promise<void> {
-        return rm(resolve(this.constants.paths.workingDir, 'VersionWriter-CopiedFiles'), {
+        return fsPromises.rm(path.resolve(this.constants.paths.workingDir, 'VersionWriter-CopiedFiles'), {
             force: true,
             recursive: true,
         });


### PR DESCRIPTION
## Summary

- Updated `@actions/github` to the current major version to pull in a newer `undici`, move off the old dependency tree, and resolve the current security alerts tied to the vulnerable version.
- Migrated `tools/*` to ESM so the workspace remains compatible with the updated `@actions/github` package without relying on compatibility shims.
- Cleaned up imports across the `tools` workspace: standardized import grouping, separated value and type imports, replaced `util.promisify(fs...)` with `fs/promises`, and removed unused imports.
- Fixed pre-existing TypeScript issues and tightened typing by adding `js-ini` type guards, refining release/publish/IRC/SSH service types, and moving config interfaces from `class` to `interface`.
- Removed duplicated type annotations from JSDoc while keeping the useful descriptions.
- Added explicit `process.exitCode` handling to the relevant entrypoints and test scripts so failures are reported consistently in CI.

## Notes

- Replaced internal `@actions/github/lib/...` imports with the public `@actions/github` API.
- GitHub context handling now uses local types derived from `context`, without relying on the package's internal classes.
- Completed the ESM migration across `tools/*`, including workspace packages and related imports.
- Improved type safety and readability in `mpmaps-updater` and `build-installer` as part of the migration.

## Verification

All checks that were practical to run locally for this change set were completed successfully:
```sh
cd ./tools

npx tsc -p tsconfig.json
npx prettier "**/*.{ts,json}" --write --fix

npm run map-name-case-fix
npm run mpmaps-updater
npm run mix-packer
npm run version-writer
npm run build-installer
npm run test-release-tag-validator
npm run test-release-asset-uploader
npm run test-publish-release
```
