### PR TITLE
Correct outdated Chinese (Simplified) translation of update text

### DIFF
--- a/package/Resources/Translations/zh-Hans/Translation.ini
+++ b/package/Resources/Translations/zh-Hans/Translation.ini
@@ -297,7 +297,7 @@ Client:DTAConfig:Unpacking=正在解压...
 ; Unpacking...
 Client:DTAConfig:Update=更新
 ; Update
-Client:DTAConfig:UpdateConfirmRequiredText=为开启 {0}，客户端需要将所需的文件下载到您的游戏安装目录。@@这会占用 {1} 的硬盘空间，且根据您的网络质量，@下载时间从几分钟到几小时不定。@@下载期间，您不能进行游戏。确实要继续吗？
+Client:DTAConfig:UpdateConfirmRequiredText=为开启 {0}，客户端需要将所需的文件下载到您的游戏安装目录。@@这会占用额外的 {1} 硬盘空间，下载大小为 {2}，下载时间因网络质量@而异。@@下载期间，您无法进行游戏。是否继续？
 ; To enable {0} the Client will need to download the necessary files to your game directory.@@This will take an additional {1} of disk space, and the download may take some time@depending on your Internet connection speed. The size of the download is {2}.@@You will not be able to play during the download. Do you wish to continue?
 Client:DTAConfig:UpdateConfirmRequiredTitle=需要确认
 ; Confirmation Required


### PR DESCRIPTION
## Fix missing placeholder `{2}` and restore functional parity with source text

This PR addresses a **missing formatting parameter** in the Chinese localization that currently removes important information from the UI.

---

### Missing `{2}` placeholder causes loss of download size information

The original string contains **three format parameters**:

- `{0}` — component name  
- `{1}` — disk space required  
- `{2}` — download size  

The existing translation preserved `{0}` and `{1}`, but **removed `{2}` together with the entire clause containing it**, which makes the “download size” information disappear from the interface.

This is not a stylistic choice — it is a **functional regression**.  
Before confirming a download, users are supposed to see three pieces of information:

1. Disk space required  
2. Download size  
3. Estimated waiting time  

Currently, only the first two remain visible.

---

### Unjustified addition of estimated time range

The original text states:

> *“the download may take some time depending on your Internet connection speed”*

The current translation renders this as:

> *“下载时间从几分钟到几小时不定”* (from minutes to hours)

This introduces a **time estimate that does not exist in the source text**.  
Localization should not speculate or add concrete ranges that the original deliberately avoids.

---

### This correction is indisputable

The `{2}` placeholder appears in its own clause in the source string and should be straightforward to retain.  
Losing a formatting parameter at the PR stage suggests the need for stricter attention to placeholder preservation during localization.

It would be beneficial to introduce **automated placeholder validation in CI** to reduce reliance on manual detection of such issues and to prevent similar regressions in the future.

**It has sufficient grounds to raise concerns about the original author's qualifications and translation quality. This translation still contains multiple imprecise and basic errors. Persistently serving users a dish that is still incomplete does not align with software engineering principles. A thorough review is recommended; otherwise, it may degrade the overall quality of this open-source project.**