### PR TITLE
Correct Chinese (Simplified) translation of "Play sound when a game is hosted"

### DIFF
--- a/package/Resources/Translations/zh-Hans/Translation.ini
+++ b/package/Resources/Translations/zh-Hans/Translation.ini
@@ -189,7 +189,7 @@ Client:DTAConfig:PingUnofficial=检测非官方 CnCNet 服务器的延迟
 ; Ping unofficial CnCNet tunnels
 Client:DTAConfig:PlayerName=玩家昵称: 
 ; Player Name*:
-Client:DTAConfig:PlaySoundGameHosted=创建游戏房间后仍播放背景音乐
+Client:DTAConfig:PlaySoundGameHosted=有游戏房间创建时播放提示音
 ; Play sound when a game is hosted
 Client:DTAConfig:PMAll=全接收
 ; All


### PR DESCRIPTION
# This translation has two distinct errors:

1. **"sound" → "背景音乐" (background music)**
   The source refers to a notification *sound effect* triggered by an event — not background music. These are entirely different UI concepts. "背景音乐" implies ambient/looping audio that plays continuously, which is the opposite of what this setting controls.

2. **"仍" (still/continue) — fabricated adverb**
   The word "仍" does not correspond to anything in the source string. Its insertion implies this sound plays *despite* some other condition (e.g. "even when muted"), which is a meaning the original does not carry at all. This is not creative translation — it is adding information that isn't there.

The net effect is that the translated string describes a completely different setting from the one it labels. A user reading `创建游戏房间后仍播放背景音乐` would reasonably assume this toggle controls whether *background music* continues during lobby creation — not whether a *notification sound* fires when someone *else* hosts a game.

This is clearly a basic machine translation mistake. It is advisable to verify whether the original translator is a native Mandarin speaker. There are still many errors in this translation file, It is recommended to fix the remaining errors ASAP.
