### PR TITLE
Update Chinese (Simplified) translation for consistency of "Load"

### DIFF
--- a/package/Resources/Translations/zh-Hans/Translation.ini
+++ b/package/Resources/Translations/zh-Hans/Translation.ini
@@ -417,7 +417,7 @@ Client:Main:ChatboxCommandHideMapsHelp=隐藏地图列表 (仅限房主使用)
 ; Hide map list (game host only)
 Client:Main:ChatboxCommandHostOnly=/{0} 仅限房主使用。
 ; /{0} is for game hosts only.
-Client:Main:ChatboxCommandLoadMapHelp=从 /Maps/Custom/ 文件夹下载入指定文件。
+Client:Main:ChatboxCommandLoadMapHelp=从 /Maps/Custom/ 文件夹载入指定文件。
 ; Load a custom map with given filename from /Maps/Custom/ folder.
 Client:Main:ChatboxCommandLoadOptionsHelp=载入游戏规则预设
 ; Load game option preset

--- a/package/Resources/Translations/zh-Hans/Translation.ini
+++ b/package/Resources/Translations/zh-Hans/Translation.ini
@@ -383,7 +383,7 @@ Client:Main:ButtonLaunchGame=开始游戏
 ; Launch Game
 Client:Main:ButtonLoad=载入
 ; Load
-Client:Main:ButtonLoadGame=加载存档
+Client:Main:ButtonLoadGame=载入存档
 ; Load Game
 Client:Main:ButtonLockGame=锁定房间
 ; Lock Game

--- a/package/Resources/Translations/zh-Hans/Translation.ini
+++ b/package/Resources/Translations/zh-Hans/Translation.ini
@@ -417,9 +417,9 @@ Client:Main:ChatboxCommandHideMapsHelp=隐藏地图列表 (仅限房主使用)
 ; Hide map list (game host only)
 Client:Main:ChatboxCommandHostOnly=/{0} 仅限房主使用。
 ; /{0} is for game hosts only.
-Client:Main:ChatboxCommandLoadMapHelp=从 /Maps/Custom/ 文件夹下加载指定文件。
+Client:Main:ChatboxCommandLoadMapHelp=从 /Maps/Custom/ 文件夹下载入指定文件。
 ; Load a custom map with given filename from /Maps/Custom/ folder.
-Client:Main:ChatboxCommandLoadOptionsHelp=加载游戏规则预设
+Client:Main:ChatboxCommandLoadOptionsHelp=载入游戏规则预设
 ; Load game option preset
 Client:Main:ChatboxCommandMaxAheadHelpV2=修改 MaxAhead (默认值 {0}) (仅限房主使用)
 ; Change MaxAhead (default {0}) (game host only)
@@ -441,7 +441,7 @@ Client:Main:ChatboxCommandRollInvalid3=骰子面数在 2 到 100 之间 (生成 
 ; You can only have between 2 and 100 sides in a die.
 Client:Main:ChatboxCommandRollInvalidAndSyntax=设定的骰子无效。标准格式: /roll <骰子数量>d<骰子面数>
 ; Invalid dice specified. Expected format: /roll <die count>d<die sides>
-Client:Main:ChatboxCommandSaveOptionsHelp=保存游戏规则预设，方便以后加载使用
+Client:Main:ChatboxCommandSaveOptionsHelp=保存游戏规则预设，方便以后载入使用
 ; Save game option preset so it can be loaded later
 Client:Main:ChatboxCommandShowMapsHelp=显示地图列表 (仅限房主使用)
 ; Show map list (game host only)
@@ -625,7 +625,7 @@ Client:Main:DownloadMapCommandDescription=使用地图 ID 和地图文件名从 
 ; Download a map from CNCNet's map server using a map ID and an optional filename.@Example: "/downloadmap MAPID [2] My Battle Map"
 Client:Main:DownloadMapCommandFailedGeneric=使用聊天栏命令下载地图失败。请检查地图 ID 并重试。
 ; Downloading map via chat command has failed. Check the map ID and try again.
-Client:Main:DownloadMapCommandSha1AlreadyExists=地图 ID "{0}" 已被 "{1}.{2}" 加载，请删除现有文件，然后重试。
+Client:Main:DownloadMapCommandSha1AlreadyExists=地图 ID "{0}" 已被 "{1}.{2}" 载入，请删除现有文件，然后重试。
 ; The map for ID "{0}" is already loaded from "{1}.{2}", delete the existing file before trying again.
 Client:Main:DownloadMapCommandStartingDownload=正在尝试使用聊天栏命令下载地图: sha1={0}，地图名={1}
 ; Attempting to download map via chat command: sha1={0}, mapName={1}
@@ -919,7 +919,7 @@ Client:Main:LoadPreset=载入方案
 ; Load Preset
 Client:Main:LobbyF3=CnCNet 大厅 (F3)
 ; CnCNet Lobby (F3)
-Client:Main:LobbyInitialTip=等待所有玩家加入并且准备好之后，点击载入游戏按钮以加载保存的多人游戏存档。
+Client:Main:LobbyInitialTip=等待所有玩家加入并且准备好之后，点击载入游戏按钮以载入保存的多人游戏存档。
 ; Wait for all players to join and get ready, then click Load Game to load the saved multiplayer game.
 Client:Main:LobbyPassword=密码: 
 ; Password:
@@ -1153,7 +1153,7 @@ Client:Main:PMLabel=私人信息
 ; PRIVATE MESSAGING
 Client:Main:PreferredSkillLevel=期望的游戏水平: 
 ; Preferred skill level:
-Client:Main:PresetLoaded=游戏规则预设加载成功。
+Client:Main:PresetLoaded=游戏规则预设载入成功。
 ; Game option preset loaded succesfully.
 Client:Main:PresetName=预设方案名称
 ; Preset Name
@@ -1445,13 +1445,13 @@ Client:Main:YourColor=您的颜色:
 ; YOUR COLOR:
 Client:Main:YouWereKicked=您已被踢出房间！
 ; You were kicked from the game!
-Client:MapLoader:MapAlreadyLoaded=地图 {0} 已加载。
+Client:MapLoader:MapAlreadyLoaded=地图 {0} 已载入。
 ; Map {0} is already loaded.
 Client:MapLoader:MapFileDoesNotExist=地图 {0} 不存在！
 ; Map file {0} doesn't exist!
-Client:MapLoader:MapLoadedSuccessfully=地图 {0} 加载成功。
+Client:MapLoader:MapLoadedSuccessfully=地图 {0} 载入成功。
 ; Map {0} loaded successfully.
-Client:MapLoader:MapLoadingFailed=地图 {0} 加载失败！
+Client:MapLoader:MapLoadingFailed=地图 {0} 载入失败！
 ; Loading map {0} failed!
 Client:Sides:RandomSide=随机阵营
 ; Random

--- a/package/Resources/Translations/zh-Hans/Translation.ini
+++ b/package/Resources/Translations/zh-Hans/Translation.ini
@@ -189,7 +189,7 @@ Client:DTAConfig:PingUnofficial=检测非官方 CnCNet 服务器的延迟
 ; Ping unofficial CnCNet tunnels
 Client:DTAConfig:PlayerName=玩家昵称: 
 ; Player Name*:
-Client:DTAConfig:PlaySoundGameHosted=创建游戏房间后仍播放背景音乐
+Client:DTAConfig:PlaySoundGameHosted=有游戏房间创建时播放提示音
 ; Play sound when a game is hosted
 Client:DTAConfig:PMAll=全接收
 ; All


### PR DESCRIPTION
The verb "load" is currently translated inconsistently
sometimes as `载入`, sometimes as `加载`. All instances should use `载入`.

While both are technically understandable in Chinese, they carry slightly different stylistic and technical connotations:

**载入** → more commonly used in **UI/technical/game context** (loading resources, maps, saves)
**加载** → more general-purpose, often used in **system/engineering context**

Since this project is a game UI localization, consistency and in-game terminology clarity are important for user experience.