### PR TITLE
Chinese Translation Correction: Translation consistency for "Team"

### DIFF
--- a/package/Resources/Translations/zh-Hans/Translation.ini
+++ b/package/Resources/Translations/zh-Hans/Translation.ini
@@ -1315,7 +1315,7 @@ Client:Main:StatisticsScore=分数
 ; SCORE
 Client:Main:StatisticsSide=阵营
 ; SIDE
-Client:Main:StatisticsTeam=小队
+Client:Main:StatisticsTeam=队伍
 ; TEAM
 Client:Main:StatisticsTotalKills=总摧毁数: 
 ; Total kills:
@@ -1343,7 +1343,7 @@ Client:Main:SupplementalFileCopyError=无法复制追加地图文件
 ; Unable to copy supplemental map file
 Client:Main:SupplementalFileDeleteError=无法删除追加地图文件
 ; Unable to delete supplemental map file
-Client:Main:TeamAsANoun=小队选择
+Client:Main:TeamAsANoun=队伍选择
 ; team selection
 Client:Main:ToggleExtraIcons=切换额外图标
 ; Toggle Extra Icons
@@ -1863,7 +1863,7 @@ INI:Controls:PlayerOptionsPanel:lblSide:Text=阵营
 ; Side
 INI:Controls:PlayerOptionsPanel:lblStart:Text=位置
 ; Start
-INI:Controls:PlayerOptionsPanel:lblTeam:Text=小队
+INI:Controls:PlayerOptionsPanel:lblTeam:Text=队伍
 ; Team
 INI:Controls:SkirmishLobby:btnAres:ToolTip=Ares 是新一代基于二进制的《命令与征服》引擎修改工具@@版本: 3.0p1
 ; Ares is the next generation of binary-based Command & Conquer modding@@Version: 3.0p1
@@ -1933,7 +1933,7 @@ INI:GameModes:Standard:UIName=作战
 ; Standard
 INI:GameModes:Survival:UIName=生存
 ; Survival
-INI:GameModes:Team Alliance:UIName=小队联盟
+INI:GameModes:Team Alliance:UIName=队伍联盟
 ; Team Alliance
 INI:GameModes:Unholy Alliance:UIName=邪恶联盟
 ; Unholy Alliance
@@ -1951,7 +1951,7 @@ INI:HotkeyCategories:Selection=选择
 ; Selection
 INI:HotkeyCategories:Taunts=嘲讽
 ; Taunts
-INI:HotkeyCategories:Team=小队
+INI:HotkeyCategories:Team=队伍
 ; Team
 INI:Hotkeys:AllToCheer:Description=使您所有的步兵单位为您喝彩。
 ; Make all of your infantry units cheer.


### PR DESCRIPTION
## 🔵 Translation Consistency Issue: `Team` Term Inconsistency

### Problem Summary
The term **“Team”** is currently translated inconsistently across the UI as both:

- `小队`
- `队伍`

Although both are understandable in Chinese, they are used in different contexts and create **terminology fragmentation** in the UI.

This leads to:
- Inconsistent player-facing language across menus
- Reduced UI polish and professional localization quality
- Potential confusion in competitive/gameplay contexts where “Team” has a specific meaning

---

### Current Inconsistencies Found

| Location | Current Translation |
|----------|---------------------|
| `Client:Main:StatisticsTeam` | 小队 |
| `Client:Main:PlayerOptionTeam` | 队伍 |
| `INI:Controls:PlayerOptionsPanel:lblTeam:Text` | 小队 |
| `INI:HotkeyCategories:Team` | 小队 |

---

### Recommendation

Standardize all occurrences of **Team → 队伍** (recommended for RTS / multiplayer UI consistency).

#### Rationale:
- `队伍` is more commonly used in **multiplayer / RTS / competitive game contexts**
- Better matches player expectation for grouping / faction / team-based systems
- More consistent with standard Chinese game localization conventions

---

### Proposed Fix

```ini
Client:Main:StatisticsTeam=队伍
Client:Main:PlayerOptionTeam=队伍
INI:Controls:PlayerOptionsPanel:lblTeam:Text=队伍
INI:HotkeyCategories:Team=队伍