### PR TITLE
Chinese Translation Correction: Consistency for "Tunnel Server"

### DIFF
--- a/package/Resources/Translations/zh-Hans/Translation.ini
+++ b/package/Resources/Translations/zh-Hans/Translation.ini
@@ -1359,7 +1359,7 @@ Client:Main:TOSExplanation=使用此应用程序即表示您同意《CnCNet 服�
 ; By using this application you agree to the CnCNet Terms & Conditions as well as the CnCNet Privacy Policy. Privacy-related options can be configured in the client settings.
 Client:Main:TOSMoreInfo=CNCNet 相关协议条款: 
 ; More information:
-Client:Main:TOSText=此应用程序使用 CnCNet 网络和隧道服务器服务，并通过它们收集技术和其他必要信息。
+Client:Main:TOSText=此应用程序使用 CnCNet 网络和服务器服务，并通过它们收集技术和其他必要信息。
 ; This application makes use of CnCNet web & tunnel server services and is subject to collection of technical & other necessary information through them.
 Client:Main:TotalProgressPercentage=总进度百分比: 
 ; Total progress percentage:
@@ -1825,7 +1825,7 @@ INI:Controls:MainMenu:lblVersionLabel:Text=客户端版本:
 ; Client Version:
 INI:Controls:MultiplayerGameLobby:btnAres:ToolTip=Ares 是新一代基于二进制的《命令与征服》引擎修改工具@@版本: 3.0p1
 ; Ares is the next generation of binary-based Command & Conquer modding@@Version: 3.0p1
-INI:Controls:MultiplayerGameLobby:btnChangeTunnel:Text=更换隧道服务器
+INI:Controls:MultiplayerGameLobby:btnChangeTunnel:Text=更换服务器
 ; Change Tunnel
 INI:Controls:MultiplayerGameLobby:btnCnCNet:ToolTip=CnCNet - 红色警戒 2 及尤里的复仇在线游戏
 ; CnCNet - Red Alert 2 & Yuri's Revenge Online


### PR DESCRIPTION
If i'm right, i remember we already discussed this issue last year

In the current translation, most instances of "Tunnel Server" are localized as `"服务器"`. However, a few lines remained as `"隧道服务器",` which sounds so weird, redundant and inconsistent in this context.

I think it's not advisable to use `“隧道服务器” `bcuz for ordinary players, these overly technical terms can be confusing.

To improve the user experience and maintain a professional UI, I have unified these terms to `"服务器"`

This is the 8th PR related to Chinese corrections. Please be noted other potential errors are still being investigated. I'm sure these kinds of original author's low level mistakes will lead to a poor experience for Chinese users and could even result in potential user loss.