### PR TITLE
RadialIndicatorVisibility for ally

### DIFF
--- a/game-assets/cncnet.pack/rulesmd.ini
+++ b/game-assets/cncnet.pack/rulesmd.ini
@@ -800,6 +800,7 @@ PlacementPreview.Translucency=75
 
 ; Phobos fixes
 UseRetintFix=no ; CCCP84 Nov 2025: Activating this fix leads to an increase in lags during re-tinting by tens of times
+RadialIndicatorVisibility=ally ; CCCP84 Apr 2026: Shows the building's action circle to a teammates
 
 ; ******* Crate rules *******
 ; General crate rules and controls are specified here.

--- a/game-assets/ra2mode.pack/rulesmd.ini
+++ b/game-assets/ra2mode.pack/rulesmd.ini
@@ -705,6 +705,7 @@ PlacementPreview.Translucency=75
 
 ; Phobos fixes
 UseRetintFix=no ; CCCP84 Nov 2025: Activating this fix leads to an increase in lags during re-tinting by tens of times
+RadialIndicatorVisibility=ally ; CCCP84 Apr 2026: Shows the building's action circle to a teammates
 
 ; ******* Crate rules *******
 ; General crate rules and controls are specified here.


### PR DESCRIPTION
This shows the limits of the sensors, gapgenerators for teammates. I don't see any negative aspects in this, only positive ones. It's convenient and everyone will approve of it.
I already tested this in my maps. works without any problems.