### PR TITLE
Ignore KeyboardMD.ini

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,4 @@ package/Tools/Map Editor/FA2SP/syringe.log
 package/Tools/Map Editor/WAE/MapEditorLog.log
 package/Tools/Map Editor/WAE/MapEditorSettings.ini
 package/Tools/Map Editor/WAE/UserData/MissingTranslationValues.ini
+package/KeyboardMD.ini


### PR DESCRIPTION
The next release of cncnet client is able to automatically apply modders' default hotkeys as long as they are not occupied by users. Therefore it is necessary to ignore including this file in git.