### PR TITLE
RA2 AttackCursorOnDisguise=yes

### DIFF
--- a/game-assets/ra2mode.pack/rulesmd.ini
+++ b/game-assets/ra2mode.pack/rulesmd.ini
@@ -274,7 +274,7 @@ SovietDisguise=E2 ; CCCP84: 04.2026 In Yuri's Revenge engine, this is no longer 
 ThirdDisguise=E2 ; CCCP84: 04.2026 This used by default. In RA2 avoid using Yuri's units as camouflage, this may cause error
 SpyPowerBlackout=1000 ; Frame time a spy shuts down power for (900 = 1 minute)
 SpyMoneyStealPercent=.5 ; Percent of total money you take with a spy
-AttackCursorOnDisguise=no ;gs If yes, the mouse will be an attack cursor on a disguised unit as if he is not disguised.
+AttackCursorOnDisguise=yes ;gs If yes, the mouse will be an attack cursor on a disguised unit as if he is not disguised.
 								;If no, you will still get an attack cursor on a fake-blinking Mirage and a spy _always_
 
 ; SJM: Default disguise for the Mirage Tank (object type)


### PR DESCRIPTION
This change aligns RA2 behavior with YR by allowing players to attack disguised units (Mirages, Spies) without holding Ctrl.

Advantages:
-Consistency with YR: Many players are already used to Yuri’s Revenge behavior. Unifying both modes reduces friction and confusion.
-Full mouse-only gameplay: **Ctrl was the only required keyboard button**. Removing it enables playing entirely with the mouse, including all menus (useful for accessibility, tablets, or limited input setups).
-Improved usability: Reduces missed inputs and accidental attacks on empty ground when Ctrl is held. Player intent becomes clearer and more reliable.

A small QoL improvement with multiple practical benefits and no real downsides.