### PR TITLE
Fix 2v2 blitz maps pointing to wrong INI

### DIFF
--- a/package/INI/MPMaps.ini
+++ b/package/INI/MPMaps.ini
@@ -18,7 +18,7 @@
 16=Oil In Centre
 
 [Oil In Centre]
-CustomIniPath=INI\Map Code\Standard.ini
+MapCodeIniName=Standard.ini
 ForcedOptions=Oil In CentreForcedOptions
 ForcedSpawnIniOptions=Oil In CentreForcedSpawnIniOptions
 
@@ -29,14 +29,14 @@ chkAutoRepair=false
 GameMode=1
 
 [Battle]
-CustomIniPath=INI\Map Code\Standard.ini
+MapCodeIniName=Standard.ini
 ForcedSpawnIniOptions=BattleForcedSpawnIniOptions
 
 [BattleForcedSpawnIniOptions]
 GameMode=1
 
 [Free For All]
-CustomIniPath=INI\Map Code\Free For All.ini
+MapCodeIniName=Free For All.ini
 ForcedOptions=Free For AllForcedOptions
 ForcedSpawnIniOptions=Free For AllForcedSpawnIniOptions
 
@@ -48,13 +48,13 @@ GameMode=2
 
 [RA2 A Class Tournament]
 MetaData.Comment=The settings for RA2 A Class Tournament
-CustomIniPath=INI\Map Code\RA2 A Class Tournament.ini
+MapCodeIniName=RA2 A Class Tournament.ini
 ForcedOptions=RA2 LadderForcedOptions
 ForcedSpawnIniOptions=RA2 LadderForcedSpawnIniOptions
 
 [RA2 Ladder]
 MetaData.Comment=The settings for RA2 Ladder
-CustomIniPath=INI\Map Code\RA2 Ladder.ini
+MapCodeIniName=RA2 Ladder.ini
 ForcedOptions=RA2 LadderForcedOptions
 ForcedSpawnIniOptions=RA2 LadderForcedSpawnIniOptions
 
@@ -86,7 +86,7 @@ GameMode=1
 
 [YR Ladder]
 MetaData.Comment=The settings for Yuri's Revenge Quick Match
-CustomIniPath=INI\Map Code\YR Ladder.ini
+MapCodeIniName=YR Ladder.ini
 ForcedOptions=YR LadderForcedOptions
 ForcedSpawnIniOptions=YR LadderForcedSpawnIniOptions
 
@@ -114,7 +114,7 @@ GameMode=1
 
 [RA2 Pro 2v2]
 MetaData.Comment=The settings for RA2 Ladder
-CustomIniPath=INI\Map Code\RA2 Pro 2v2.ini
+MapCodeIniName=RA2 Pro 2v2.ini
 ForcedOptions=RA2 Pro 2v2ForcedOptions
 ForcedSpawnIniOptions=RA2 Pro 2v2ForcedSpawnIniOptions
 
@@ -143,7 +143,7 @@ chkAutoRepair=false
 GameMode=1
 
 [Cooperative]
-CustomIniPath=INI\Map Code\Cooperative.ini
+MapCodeIniName=Cooperative.ini
 ForcedOptions=CooperativeForcedOptions
 ForcedSpawnIniOptions=CooperativeForcedSpawnIniOptions
 MultiplayerOnly=yes
@@ -173,42 +173,42 @@ chkBalancePatch=false
 GameMode=3
 
 [Unholy Alliance]
-CustomIniPath=INI\Map Code\Unholy Alliance.ini
+MapCodeIniName=Unholy Alliance.ini
 ForcedSpawnIniOptions=Unholy AllianceForcedSpawnIniOptions
 
 [Unholy AllianceForcedSpawnIniOptions]
 GameMode=4
 
 [Megawealth]
-CustomIniPath=INI\Map Code\Megawealth.ini
+MapCodeIniName=Megawealth.ini
 ForcedSpawnIniOptions=MegawealthForcedSpawnIniOptions
 
 [MegawealthForcedSpawnIniOptions]
 GameMode=5
 
 [Land Rush]
-CustomIniPath=INI\Map Code\Land Rush.ini
+MapCodeIniName=Land Rush.ini
 ForcedSpawnIniOptions=Land RushForcedSpawnIniOptions
 
 [Land RushForcedSpawnIniOptions]
 GameMode=6
 
 [Meat Grinder]
-CustomIniPath=INI\Map Code\Meat Grinder.ini
+MapCodeIniName=Meat Grinder.ini
 ForcedSpawnIniOptions=Meat GrinderForcedSpawnIniOptions
 
 [Meat GrinderForcedSpawnIniOptions]
 GameMode=7
 
 [Naval War]
-CustomIniPath=INI\Map Code\Naval War.ini
+MapCodeIniName=Naval War.ini
 ForcedSpawnIniOptions=Naval WarForcedSpawnIniOptions
 
 [Naval WarForcedSpawnIniOptions]
 GameMode=8
 
 [Team Alliance]
-CustomIniPath=INI\Map Code\Team Alliance.ini
+MapCodeIniName=Team Alliance.ini
 ForcedOptions=Team AllianceForcedOptions
 ForcedSpawnIniOptions=Team AllianceForcedSpawnIniOptions
 
@@ -219,7 +219,7 @@ chkIngameAllying=false
 GameMode=9
 
 [ModMaps]
-CustomIniPath=INI\Map Code\Mod Maps.ini
+MapCodeIniName=Mod Maps.ini
 ForcedOptions=ModMapsForcedOptions
 ForcedSpawnIniOptions=ModMapsForcedSpawnIniOptions
 
@@ -229,7 +229,7 @@ ForcedSpawnIniOptions=ModMapsForcedSpawnIniOptions
 GameMode=1
 
 [Blitz]
-CustomIniPath=INI\Map Code\Blitz_2v2.ini
+MapCodeIniName=Blitz_2v2.ini
 ForcedOptions=BlitzForcedOptions
 ForcedSpawnIniOptions=BlitzForcedSpawnIniOptions
 
@@ -257,7 +257,7 @@ chkAutoRepair=false
 GameMode=1
 
 [Blitz 2v2]
-CustomIniPath=INI\Map Code\Blitz_2v2.ini
+MapCodeIniName=Blitz_2v2.ini
 ForcedOptions=Blitz 2v2ForcedOptions
 ForcedSpawnIniOptions=Blitz 2v2ForcedSpawnIniOptions
 

--- a/package/INI/MPMaps.ini
+++ b/package/INI/MPMaps.ini
@@ -219,7 +219,7 @@ chkIngameAllying=false
 GameMode=9
 
 [ModMaps]
-MapCodeIniName=Mod Maps.ini
+MapCodeIniName=Standard.ini
 ForcedOptions=ModMapsForcedOptions
 ForcedSpawnIniOptions=ModMapsForcedSpawnIniOptions
 

--- a/package/INI/MPMapsBase.ini
+++ b/package/INI/MPMapsBase.ini
@@ -19,7 +19,7 @@
 17=Oil In Centre
 
 [Oil In Centre]
-CustomIniPath=INI\Map Code\Standard.ini
+MapCodeIniName=Standard.ini
 ForcedOptions=Oil In CentreForcedOptions
 ForcedSpawnIniOptions=Oil In CentreForcedSpawnIniOptions
 
@@ -30,14 +30,14 @@ chkAutoRepair=false
 GameMode=1
 
 [Battle]
-CustomIniPath=INI\Map Code\Standard.ini
+MapCodeIniName=Standard.ini
 ForcedSpawnIniOptions=BattleForcedSpawnIniOptions
 
 [BattleForcedSpawnIniOptions]
 GameMode=1
 
 [Free For All]
-CustomIniPath=INI\Map Code\Free For All.ini
+MapCodeIniName=Free For All.ini
 ForcedOptions=Free For AllForcedOptions
 ForcedSpawnIniOptions=Free For AllForcedSpawnIniOptions
 
@@ -49,7 +49,7 @@ GameMode=2
 
 ; The settings for RA2 Ladder
 [RA2 Ladder]
-CustomIniPath=INI\Map Code\RA2 Ladder.ini
+MapCodeIniName=RA2 Ladder.ini
 ForcedOptions=RA2 LadderForcedOptions
 ForcedSpawnIniOptions=RA2 LadderForcedSpawnIniOptions
 
@@ -81,7 +81,7 @@ GameMode=1
 
 ; The settings for Yuri's Revenge Quick Match
 [YR Ladder]
-CustomIniPath=INI\Map Code\YR Ladder.ini
+MapCodeIniName=YR Ladder.ini
 ForcedOptions=YR LadderForcedOptions
 ForcedSpawnIniOptions=YR LadderForcedSpawnIniOptions
 
@@ -109,7 +109,7 @@ GameMode=1
 
 ; The settings for RA2 Ladder
 [RA2 Pro 2v2]
-CustomIniPath=INI\Map Code\RA2 Pro 2v2.ini
+MapCodeIniName=RA2 Pro 2v2.ini
 ForcedOptions=RA2 Pro 2v2ForcedOptions
 ForcedSpawnIniOptions=RA2 Pro 2v2ForcedSpawnIniOptions
 
@@ -138,7 +138,7 @@ chkAutoRepair=false
 GameMode=1
 
 [Cooperative]
-CustomIniPath=INI\Map Code\Cooperative.ini
+MapCodeIniName=Cooperative.ini
 ForcedOptions=CooperativeForcedOptions
 ForcedSpawnIniOptions=CooperativeForcedSpawnIniOptions
 MultiplayerOnly=yes
@@ -168,42 +168,42 @@ chkBalancePatch=false
 GameMode=3
 
 [Unholy Alliance]
-CustomIniPath=INI\Map Code\Unholy Alliance.ini
+MapCodeIniName=Unholy Alliance.ini
 ForcedSpawnIniOptions=Unholy AllianceForcedSpawnIniOptions
 
 [Unholy AllianceForcedSpawnIniOptions]
 GameMode=4
 
 [Megawealth]
-CustomIniPath=INI\Map Code\Megawealth.ini
+MapCodeIniName=Megawealth.ini
 ForcedSpawnIniOptions=MegawealthForcedSpawnIniOptions
 
 [MegawealthForcedSpawnIniOptions]
 GameMode=5
 
 [Land Rush]
-CustomIniPath=INI\Map Code\Land Rush.ini
+MapCodeIniName=Land Rush.ini
 ForcedSpawnIniOptions=Land RushForcedSpawnIniOptions
 
 [Land RushForcedSpawnIniOptions]
 GameMode=6
 
 [Meat Grinder]
-CustomIniPath=INI\Map Code\Meat Grinder.ini
+MapCodeIniName=Meat Grinder.ini
 ForcedSpawnIniOptions=Meat GrinderForcedSpawnIniOptions
 
 [Meat GrinderForcedSpawnIniOptions]
 GameMode=7
 
 [Naval War]
-CustomIniPath=INI\Map Code\Naval War.ini
+MapCodeIniName=Naval War.ini
 ForcedSpawnIniOptions=Naval WarForcedSpawnIniOptions
 
 [Naval WarForcedSpawnIniOptions]
 GameMode=8
 
 [Team Alliance]
-CustomIniPath=INI\Map Code\Team Alliance.ini
+MapCodeIniName=Team Alliance.ini
 ForcedOptions=Team AllianceForcedOptions
 ForcedSpawnIniOptions=Team AllianceForcedSpawnIniOptions
 
@@ -214,7 +214,7 @@ chkIngameAllying=false
 GameMode=9
 
 [Mod Maps]
-CustomIniPath=INI\Map Code\Mod Maps.ini
+MapCodeIniName=Mod Maps.ini
 ForcedOptions=ModMapsForcedOptions
 ForcedSpawnIniOptions=ModMapsForcedSpawnIniOptions
 
@@ -224,7 +224,7 @@ ForcedSpawnIniOptions=ModMapsForcedSpawnIniOptions
 GameMode=1
 
 [Blitz]
-CustomIniPath=INI\Map Code\Blitz_2v2.ini
+MapCodeIniName=Blitz_2v2.ini
 ForcedOptions=BlitzForcedOptions
 ForcedSpawnIniOptions=BlitzForcedSpawnIniOptions
 
@@ -251,7 +251,7 @@ chkAutoRepair=false
 GameMode=1
 
 [Blitz 2v2]
-CustomIniPath=INI\Map Code\Blitz_2v2.ini
+MapCodeIniName=Blitz_2v2.ini
 ForcedOptions=Blitz 2v2ForcedOptions
 ForcedSpawnIniOptions=Blitz 2v2ForcedSpawnIniOptions
 

--- a/package/INI/MPMapsBase.ini
+++ b/package/INI/MPMapsBase.ini
@@ -214,7 +214,7 @@ chkIngameAllying=false
 GameMode=9
 
 [Mod Maps]
-MapCodeIniName=Mod Maps.ini
+MapCodeIniName=Standard.ini
 ForcedOptions=ModMapsForcedOptions
 ForcedSpawnIniOptions=ModMapsForcedSpawnIniOptions
 


### PR DESCRIPTION
Also updating the other game modes that point to incorrect INI files (although it shouldn't change anything).

Draft for now, I gotta double check it. Good test map is blitz_minden_2v2. It doesn't work at all right now - can't build an oil, just refineries. Should be fixed when applying this PR.