### PR TITLE
Update SlaveMiner scan parameters in rulesmd.ini

### DIFF
--- a/game-assets/cncnet.pack/rulesmd.ini
+++ b/game-assets/cncnet.pack/rulesmd.ini
@@ -314,11 +314,11 @@ MaximumBuildingPlacementFailures=3 ;gs If the computer gets hung up on thinking 
 
 TiberiumShortScan=6;//gs revert 3; sgc was 6 ; cell radius to scan when harvesting a single patch of Tiberium
 TiberiumLongScan=48      ; cells radius to scan when looking for a new Tiberium patch to harvest
-SlaveMinerShortScan=2;8;gs the Slave Miner looks this far to decide if it needs to move closer, but the new spot needs to be SlaveMinerScanCorrection cells better to warrent moving
-SlaveMinerSlaveScan=5;14;gs slaves scan longer than the miner since they trust if things could get better, the miner would move
+SlaveMinerShortScan=8;gs the Slave Miner looks this far to decide if it needs to move closer, but the new spot needs to be SlaveMinerScanCorrection cells better to warrent moving
+SlaveMinerSlaveScan=14;gs slaves scan longer than the miner since they trust if things could get better, the miner would move
 SlaveMinerLongScan=48;gs the Slave Miner looks the far when Searching for Ore
-SlaveMinerScanCorrection=2;3;gs when a deployed slave miner decides it needs to scoot forward to get closer to the ore, there needs to be a spot that is this much better in cells to bother getting up
-SlaveMinerKickFrameDelay=55;150;gs If the SlaveMiner is in Guard for this long, he'll try to look for ore again at SlaveMinerShortScan range to find ore and wake up
+SlaveMinerScanCorrection=3;gs when a deployed slave miner decides it needs to scoot forward to get closer to the ore, there needs to be a spot that is this much better in cells to bother getting up
+SlaveMinerKickFrameDelay=150;gs If the SlaveMiner is in Guard for this long, he'll try to look for ore again at SlaveMinerShortScan range to find ore and wake up
 
 
 AISuperDefenseProbability=90,50,10; When a super is targeted AISDDistance cells away, this is the percent chance to use ForceShield


### PR DESCRIPTION
Revert changes made to slave miner scan logic. This will stop the edge case issues of slaves not harvesting gems or ore when directed to in certain situations. This should also help with them exploding, as the reports of exploding slave miners drastically increased after these changes were implemented.