### PR TITLE
Fix argument expansion in wine-game.sh

### DIFF
--- a/package/Resources/Compatibility/Unix/wine-game.sh
+++ b/package/Resources/Compatibility/Unix/wine-game.sh
@@ -1,2 +1,2 @@
 #!/bin/sh
-${WINE:=wine} Syringe.exe $@
+exec "${WINE:=wine}" Syringe.exe "$@"


### PR DESCRIPTION
`Resources/Compatibility/Unix/wine-game.sh` expands `$@` unquoted:

```sh
#!/bin/sh
${WINE:=wine} Syringe.exe $@
```

`ClientDefinitions.ini` passes the game arguments as a single argument containing spaces:

```
ExtraCommandLineParams=-i=Ares.dll -i=CnCNet-Spawner.dll -i=Phobos.dll gamemd-spawn.exe --args="-SPAWN -LOG -CD -Include -Inheritance -RA2ModeSaveID=0x8d113b94"
```

The unquoted `$@` word-splits that argument back apart, so Syringe receives `--args=-SPAWN`
and treats everything after it as its own flags. From `syringe.log`:

```
WinMain: arguments = "-SPAWN -i=Ares.dll -i=CnCNet-Spawner.dll -i=Phobos.dll gamemd-spawn.exe --args=-SPAWN -LOG -CD -Include -Inheritance -RA2ModeSaveID=0x8d113b94"
SyringeDebugger::SyringeDebugger: Unknown flag "-LOG", skipping.
SyringeDebugger::SyringeDebugger: Unknown flag "-CD", skipping.
SyringeDebugger::SyringeDebugger: Unknown flag "-Include", skipping.
SyringeDebugger::SyringeDebugger: Unknown flag "-Inheritance", skipping.
SyringeDebugger::SyringeDebugger: Unknown flag "-RA2ModeSaveID=0x8d113b94", skipping.
...
SyringeDebugger::Run: Running process to debug. cmd = "gamemd-spawn.exe -SPAWN"
```

The game therefore starts with `-SPAWN` only. Three symptoms follow, all fixed by this change:

- **Online desync.** Without `-Include` and `-Inheritance`, Ares' INI parser resolves rules
  differently from the host. Every online match desynced on start, with Ares reporting
  "A desynchronization has occurred. (One or more parser errors have been detected that might
  be responsible.)" Skirmish and single player were unaffected, since there is no host to
  disagree with.
- **RA2 campaign missions would not start.** `-RA2ModeSaveID` was dropped, so RA2 mode never
  activated.
- **No Ares debug logs.** `-LOG` was dropped, so `debug/debug.<date>-<time>.log` was never
  written — which also made the first two much harder to diagnose.

Quoting `"${WINE:=wine}"` as well, so a Wine path containing spaces (common on macOS, where
the binary usually lives inside a `.app` bundle) is not split either. `exec` is incidental:
it replaces the shell with Wine rather than leaving it waiting, and propagates the exit code.

Verified on macOS 26 with Wine 10, YR client 9.3.2: online matches now stay in sync for their
full length, the RA2 campaign launches, and `debug/` is populated. The three other client
packages are not affected — they go through `wine-game.bat` instead.
